### PR TITLE
When setting custom-resource-path, append a '/' if not already part of i...

### DIFF
--- a/src/selmer/parser.clj
+++ b/src/selmer/parser.clj
@@ -35,8 +35,12 @@
 (defn cache-off! []
   (reset! cache? false))
 
-(defn set-resource-path![path]
-  (reset! custom-resource-path path))
+(defn set-resource-path! [path]
+  (let [path (if (or (nil? path)
+                     (.endsWith path "/"))
+               path
+               (str path "/"))]
+    (reset! custom-resource-path path)))
 
 ;; expr-tags are {% if ... %}, {% ifequal ... %},
 ;; {% for ... %}, and {% block blockname %}

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -429,3 +429,11 @@
          (render "{{f|safe}}" {:f "<foo>"})))
   (is (= "<FOO>"
          (render "{{f|upper|safe}}" {:f "<foo>"}))))
+
+(deftest custom-resource-path-setting
+  (is nil? @custom-resource-path)
+  (is (= "/some/path/" (set-resource-path! "/some/path")))
+  (is (= "/any/other/path/" (set-resource-path! "/any/other/path/")))
+  (set-resource-path! nil)
+  (is nil? @custom-resource-path)
+  )


### PR DESCRIPTION
When setting the custom-resource-path, introduce a "/" at the end if not already present.

It's very normal to leave out the "/" when setting this value, but if missed, the calls to render will barf when supplied a relative path without a leading "/"

I hope this is a useful change.
