### PR TITLE
Adds optional locale to date filter

### DIFF
--- a/src/selmer/filters.clj
+++ b/src/selmer/filters.clj
@@ -114,17 +114,19 @@ map. The rest of the arguments are optional and are always strings."
        (throw-when-expecting-number n)
        (format fmt n))
 
-     ;;; Format a date, expects an instance of DateTime (Joda Time) or Date.
+     ;;; Formats a date with english locale, expects an instance of DateTime (Joda Time) or Date.
      ;;; The format can be a key from valid-date-formats or a manually defined format
      ;;; Look in
      ;;; http://joda-time.sourceforge.net/apidocs/org/joda/time/format/DateTimeFormat.html
      ;;; for formatting help.
      ;;; You can also format time with this.
+     ;;; An optional locale for formatting can be given as second parameter
      :date
-     (fn [d fmt]
+     (fn [d fmt & [locale]]
        (let [fixed-date (fix-date d)
-             ^DateTimeFormatter fmt (or (valid-date-formats fmt)
-                                        (DateTimeFormat/forPattern fmt))]
+             locale (or locale "en")
+             ^DateTimeFormatter fmt (.withLocale (or (valid-date-formats fmt)
+                                                  (DateTimeFormat/forPattern fmt)) (java.util.Locale. locale))]
          (.print fmt fixed-date)))
 
      ;;; Default if x is falsey

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -462,9 +462,12 @@
 
 
 (deftest filter-date
-  (let [date (java.util.Date.)]
+  (let [date (java.util.Date.)
+        firstofmarch (java.util.Date. 2014 2 1)]
     (is (= (.format (java.text.SimpleDateFormat. "yyyy-MM-dd HH:mm:ss") date)
-           (render "{{f|date:\"yyyy-MM-dd HH:mm:ss\"}}" {:f date})))))
+           (render "{{f|date:\"yyyy-MM-dd HH:mm:ss\"}}" {:f date})))
+    (is (= (.format (java.text.SimpleDateFormat. "MMMM" (java.util.Locale. "fr")) firstofmarch)
+           (render "{{f|date:\"MMMM\":fr}}" {:f firstofmarch})))))
 
 (deftest filter-hash-md5
   (is (= "acbd18db4cc2f85cedef654fccc4a4d8"


### PR DESCRIPTION
The date filter accepts a second, optional, parameter: a locale given
as a 2-letter ISO 639 language code like "en", "fr", "de". The date
gets formatted with this locale applied. Relevant for month names
(format "MMMM"). Examle: {{f|date:"MMMM":fr}}

Fixes #61 
