### PR TITLE
AOT compile selmer.node

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,7 @@
                  [joda-time "2.4"]
                  [commons-codec "1.10"]
                  [cheshire "5.3.1"]]
+  :aot [selmer.node]
   :repl-options {:port 10123}
   :plugins [[lein-marginalia "0.7.1"]
             [lein-midje "3.0.0"]


### PR DESCRIPTION
Some projects may declare `:skip-aot true` in their project files, resulting in requiring `selmer.parse` throwing a `ClassNotFoundException` for `selmer.node`.

I suggest Selmer AOT compile `selmer.node` to avoid this issue.
