### PR TITLE
Fixes #53: check for spaces near `=` in param assign.

### DIFF
--- a/src/selmer/util.clj
+++ b/src/selmer/util.clj
@@ -47,8 +47,13 @@
 (def ^:dynamic ^Pattern   *endblock-pattern* nil)
 
 (defn check-tag-args [args]
-  (if (even? (count (filter #{\"} args)))
-    args (exception "malformed tag arguments in " args)))
+  (cond
+    (or (.contains args "= ") (.contains args " =")) 
+    (exception "there shouldn't be spaces near `=` in param assign statement: " args)
+
+    (odd? (count (filter #{\"} args)))
+    (exception "malformed tag arguments in " args)
+    :else args))
 
 (defn read-tag-info [rdr]
   (let [buf (StringBuilder.)


### PR DESCRIPTION
At [this point](https://github.com/yogthos/Selmer/blob/ed884bd1bd8206216790f9a913de0cdceb834ecf/src/selmer/tags.clj#L202), suggested in https://github.com/yogthos/Selmer/issues/53,  we do not have all the data -- it is already splitted by space..

Simple solutions should change this code:
```clojure
(let [content (->> (.toString buf)
                       (check-tag-args)
                       (re-seq #"(?:[^\s\"]|\"[^\"]*\")+")
                       (remove empty?)
                       (map (fn [^String s] (.trim s))))]
```
from [here](https://github.com/yogthos/Selmer/blob/ed884bd1bd8206216790f9a913de0cdceb834ecf/src/selmer/util.clj#L61) by adding something like ```(-> (.toString buf) (.replace "= ") (.replace " ="))``` (not sure if this code correct). Such operation will slow down parsing procedure.
 
But in my opinion it's not idiomatic to use spaces in such places. For example, there is no spaces in HTML attributes. I think the parser should threat such as error.