### PR TITLE
Fixes typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ templates, you can use `selmer.parser/set-resource-path!` to do that:
 (selmer.parser/set-resource-path! "/var/html/templates/")
 ```
 
-It's also possible to set the sesource path in a location relative to the resource path:
+It's also possible to set the resource path in a location relative to the resource path:
 
 ```clojure
 (set-resource-path! (clojure.java.io/resource "META-INF/foo/templates"))


### PR DESCRIPTION
Also, that precise line is a little bit confusing. The phrase "the resource path" is used twice for two different meanings. Maybe a better wording gives more clarity. I didn't do it myself because I wasn't quite sure how to fix it using the correct project's terminology.