### PR TITLE
Using include parameters where the filter and tag close are different

### DIFF
--- a/src/selmer/util.clj
+++ b/src/selmer/util.clj
@@ -102,7 +102,7 @@
       (when next-ch
         (loop [ch (read-char rdr)]
           (.append buf ch)
-          (when (not= *tag-close* ch)
+          (when (and (not= *tag-close* ch) (not= *filter-close* ch))
             (recur (read-char rdr))))
         (when filter?
           (.append buf (read-char rdr)))))))


### PR DESCRIPTION
Current code base will not allow the creation of defaults with include in case the tag close and the filter close are different. This would resolve that.