### PR TITLE
Adding option to turn off escaping...

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,16 @@ in a vector with a `:safe` keyword:
 =>"<DIV>I'M SAFE</DIV>"
 ```
 
+It is possible to disable escaping entirely (if, for example, your target format is not HTML/XML):
+
+```clojure
+(require '[selmer.util :refer [turn-off-escaping!]])
+
+(turn-off-escaping!)
+
+(render "{{x}}" {:x "I <3 NY"})
+=>"I <3 NY"
+```
 
 ### Built-in Filters
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject selmer "9.0.1-SNAPSHOT"
+(defproject selmer "0.9.1-SNAPSHOT"
   :description "Django templates for Clojure"
   :url "https://github.com/yogthos/Selmer"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject selmer "0.8.9"
+(defproject selmer "9.0.1-SNAPSHOT"
   :description "Django templates for Clojure"
   :url "https://github.com/yogthos/Selmer"
   :license {:name "Eclipse Public License"

--- a/src/selmer/util.clj
+++ b/src/selmer/util.clj
@@ -17,6 +17,16 @@
                   (when (thread-bound? #'*custom-resource-path*)
                     (set! *custom-resource-path* path))))
 
+(def ^:dynamic *escape-variables* true)
+
+(defn turn-off-escaping! []
+  (alter-var-root #'*escape-variables*
+                  (constantly false)))
+
+(defn turn-on-escaping! []
+  (alter-var-root #'*escape-variables*
+                  (constantly true)))
+
 (defn pattern [& content]
   (re-pattern (clojure.string/join content)))
 

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -686,3 +686,12 @@
     (is (= "I &lt;3 ponies" (render "{{name|default-if-empty:\"I <3 ponies\"}}" {:name nil})))
     (is (= "I &lt;3 ponies" (render "{{name|default-if-empty:\"I <3 ponies\"}}" {:name []})))
     (is (= "I &lt;3 ponies" (render "{{name|default-if-empty:\"I <3 ponies\"}}" {})))))
+
+(deftest turn-off-escaping
+  (testing "with escaping turned off"
+    (try
+      (turn-off-escaping!)
+      (is (= "I <3 ponies" (render "{{name}}" {:name "I <3 ponies"})))
+      (is (= "I <3 ponies" (render "{{name|default-if-empty:\"I <3 ponies\"}}" {})))
+      (is (= "I <3 ponies" (render "{{name|default-if-empty:\"I <3 ponies\"|safe}}" {})))
+      (finally (turn-on-escaping!)))))


### PR DESCRIPTION
 ...using dynamic var selmer.util/*escape-variables*.

I think you might need to tweak the project version number (latest jar is 0.9.0, but master says 0.8.9 - I used 0.9.1-SNAPSHOT). Also I updated the README and added a test.

How soon can you deploy a new jar? I can have my fellow devs install the SNAPSHOT locally, but that won't be necessary if you can turn this around quickly.  