### PR TITLE
Better way of turning off escaping.

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,16 +267,18 @@ in a vector with a `:safe` keyword:
 =>"<DIV>I'M SAFE</DIV>"
 ```
 
-It is possible to disable escaping entirely (if, for example, your target format is not HTML/XML):
+It is possible to disable escaping (if, for example, your target format is not HTML/XML) using the `selmer.util/without-escaping` macro:
 
 ```clojure
-(require '[selmer.util :refer [turn-off-escaping!]])
+(require '[selmer.util :refer [without-escaping]])
 
-(turn-off-escaping!)
-
-(render "{{x}}" {:x "I <3 NY"})
+(without-escaping
+  (render "{{x}}" {:x "I <3 NY"}))
 =>"I <3 NY"
 ```
+
+Alternatively, you can turn off escaping permanently in all threads with the `selmer.util/turn-off-escaping!` function.
+
 
 ### Built-in Filters
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject selmer "0.9.2"
+(defproject selmer "0.9.3-SNAPSHOT"
   :description "Django templates for Clojure"
   :url "https://github.com/yogthos/Selmer"
   :license {:name "Eclipse Public License"

--- a/src/selmer/util.clj
+++ b/src/selmer/util.clj
@@ -27,6 +27,14 @@
   (alter-var-root #'*escape-variables*
                   (constantly true)))
 
+(defmacro with-escaping [& body]
+  `(binding [*escape-variables* true]
+     ~@body))
+
+(defmacro without-escaping [& body]
+  `(binding [*escape-variables* false]
+     ~@body))
+
 (defn pattern [& content]
   (re-pattern (clojure.string/join content)))
 

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -692,11 +692,30 @@
     (is (= "I &lt;3 ponies" (render "{{name|default-if-empty:\"I <3 ponies\"}}" {:name []})))
     (is (= "I &lt;3 ponies" (render "{{name|default-if-empty:\"I <3 ponies\"}}" {})))))
 
-(deftest turn-off-escaping
+(deftest turn-off-escaping-test
   (testing "with escaping turned off"
     (try
       (turn-off-escaping!)
       (is (= "I <3 ponies" (render "{{name}}" {:name "I <3 ponies"})))
       (is (= "I <3 ponies" (render "{{name|default-if-empty:\"I <3 ponies\"}}" {})))
       (is (= "I <3 ponies" (render "{{name|default-if-empty:\"I <3 ponies\"|safe}}" {})))
+      (finally (turn-on-escaping!)))))
+
+(deftest without-escaping-test
+  (testing "without-escaping macro"
+    (without-escaping
+     (is (= "I <3 ponies" (render "{{name}}" {:name "I <3 ponies"}))))
+    ;; ensure escaping is on after the macro.
+    (is (= "<tag>&lt;foo bar=&quot;baz&quot;&gt;\\&gt;</tag>"
+         (render "<tag>{{f}}</tag>" {:f "<foo bar=\"baz\">\\>"})))))
+
+(deftest with-escaping-test
+  (testing "with-escaping macro when turn-off-escaping! has been called"
+    (try
+      (turn-off-escaping!)
+      (is (= "I <3 ponies" (render "{{name}}" {:name "I <3 ponies"})))
+      (with-escaping
+        (is (= "<tag>&lt;foo bar=&quot;baz&quot;&gt;\\&gt;</tag>"
+               (render "<tag>{{f}}</tag>" {:f "<foo bar=\"baz\">\\>"}))))
+      (is (= "I <3 ponies" (render "{{name}}" {:name "I <3 ponies"})))
       (finally (turn-on-escaping!)))))


### PR DESCRIPTION
My previous contribution to turn off escaping was a bit naive. It changes the root binding of the var that controls escaping. However, if someone wishes to turn escaping on/off in different threads (already running into this), then we need to use (binding). I have included 2 new macros to turn escaping on/off within it's body.