### PR TITLE
Add support for @-prefixed filter arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,9 @@ For example, if we wanted to convert the variable to upper case we could write `
 rendered with `{:user-name "Yogthos"}` it would produce `YOGTHOS` as its output.
 
 Some filters can take parameters. `{{domain|hash:"md5"}}` rendered with `{:domain "example.org"}` would produce
-`1bdf72e04d6b50c82a48c7e4dd38cc69`.
+`1bdf72e04d6b50c82a48c7e4dd38cc69`. If a parameter begins with `@` it will be looked up in the context map and,
+if found, will be replaced with its value before
+being passed to the filter function. For example, `@foo.bar` will treated as `(get-in context-map [:foo :bar] "@foo.bar")`.
 
 Finally, you can easily register custom filters in addition to those already provided. A filter is simply a function
 that accepts a value and returns its replacement:

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject selmer "0.9.3"
+(defproject selmer "0.9.4"
   :description "Django style templates for Clojure"
   :url "https://github.com/yogthos/Selmer"
   :license {:name "Eclipse Public License"

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -627,6 +627,19 @@
   (is (= "<FOO>"
          (render "{{f|upper|safe}}" {:f "<foo>"}))))
 
+;; test @-syntax for dereferencing context map in filter arguments
+(deftest test-deref-filter-arg
+  (is (= " Sean " ;; note center filter expects String for width!
+         (render "{{name|center:@width}}" {:name "Sean" :width "6"})))
+  (is (= "4" ;; ensure we can substitute a data structure
+         (render "{{name|default:@v|count}}" {:v [1 2 3 4]})))
+  (is (= "@" ;; literal @ is not dereferenced
+         (render "{{name|default:@}}" {:name nil})))
+  (is (= "@foo" ;; literal @foo used when no context map match
+         (render "{{name|default:@foo}}" {:name nil})))
+  (is (= "quux" ;; test nested lookup
+         (render "{{name|default:@foo.bar.baz}}" {:name nil :foo {:bar {:baz "quux"}}}))))
+
 (deftest custom-resource-path-setting
   (is nil? *custom-resource-path*)
   (is (= "file:////some/path/" (set-resource-path! "/some/path")))


### PR DESCRIPTION
Filter arguments prefixed with @ are looked up in the context map before
being passed to the filter function. Dot notation (@x.y.z) is
supported. A single @ is treated as a literal argument. If an argument
beginning with @ is not found in the context map, it is treated as a
literal argument (for backward compatibility).

Bumped the project version to 0.9.4 to indicate the new feature (so a
release can be cut a.s.a.p.).