### PR TITLE
Add short-form comment syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,7 +699,11 @@ renders current time
 #### comment
 ignores any content inside the block
 
-`(render "foo bar {% comment %} baz test {{x}} {% endcomment %} blah" {})` => `"foo bar  baz test  blah"`
+`(render "foo bar {% comment %} baz test {{x}} {% endcomment %} blah" {})` => `"foo bar  blah"`
+
+A short form is also available:
+
+`(render "foo bar {# baz test {{x}} #} blah" {})` => `"foo bar  blah"`
 
 #### firstof
 renders the first occurance of supplied keys that doesn't resolve to false:

--- a/src/selmer/parser.clj
+++ b/src/selmer/parser.clj
@@ -197,9 +197,12 @@
 (defn skip-short-comment-tag [template rdr]
   (loop [ch1 (read-char rdr)
          ch2 (read-char rdr)]
-    (if (and (= *short-comment-second* ch1) (= *tag-close* ch2))
+    (cond
+      (nil? ch2)
+      (exception "short-form comment tag was not closed")
+      (and (= *short-comment-second* ch1) (= *tag-close* ch2))
       template
-      (recur ch2 (read-char rdr)))))
+      :else (recur ch2 (read-char rdr)))))
 
 ;; Compile-time parsing of tags. Accumulates a transient vector
 ;; before returning the persistent vector of INodes (TextNode, FunctionNode)

--- a/src/selmer/util.clj
+++ b/src/selmer/util.clj
@@ -56,6 +56,7 @@
 (def ^:dynamic ^Character *filter-open* \{)
 (def ^:dynamic ^Character *filter-close* \})
 (def ^:dynamic ^Character *tag-second* \%)
+(def ^:dynamic ^Character *short-comment-second* \#)
 
 ;; tag regex patterns
 (def ^:dynamic ^Pattern   *tag-second-pattern* nil)
@@ -130,6 +131,11 @@
        (let [next-ch (peek-rdr rdr)]
          (or (= *filter-open* next-ch)
              (= *tag-second* next-ch)))))
+
+(defn open-short-comment? [ch rdr]
+  (and (= *tag-open* ch)
+       (let [next-ch (peek-rdr rdr)]
+         (= *short-comment-second* next-ch))))
 
 (defn split-by-args [s]
   (let [rdr (StringReader. s)

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -164,7 +164,10 @@
       (render "foo bar {% comment %} baz test {{x}} {% endcomment %} blah" {})))
   (is
     (= "foo bar  blah"
-       (render "foo bar {% comment %} baz{% if x %}nonono{%endif%} test {{x}} {% endcomment %} blah" {}))))
+       (render "foo bar {% comment %} baz{% if x %}nonono{%endif%} test {{x}} {% endcomment %} blah" {})))
+  (is
+    (= "foo bar  blah"
+       (render "foo bar {# baz test {{x}} #} blah" {}))))
 
 
 (deftest test-firstof


### PR DESCRIPTION
This is an attempt to close https://github.com/yogthos/Selmer/issues/51. Short-form comment tags like `{# this is a comment #}` will be dropped by the parser. 