### PR TITLE
Add toString implementation to TextNode

### DIFF
--- a/src/selmer/node.clj
+++ b/src/selmer/node.clj
@@ -23,4 +23,6 @@
 (deftype TextNode [text]
   INode
   (render-node [this context-map]
+    text)
+  (toString [_]
     text))


### PR DESCRIPTION
For ease of debugging, REPL interaction etc, add toString
implementation for TextNode which simply returns the node text.

E.g.
```
;; before:
(TextNode. "foo")
=> #object[selmer.node.TextNode 0x4a55c661 "selmer.node.TextNode@4a55c661"]

;; after:
(TextNode. "foo")
=> #object[selmer.node.TextNode 0x4a55c661 "foo"]
```