### PR TITLE
changed filter_parser to allow for double dots form of escape

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A fast, [Django](https://docs.djangoproject.com/en/dev/ref/templates/builtins/) 
 
 #### Leiningen
 
-[![Clojars Project](http://clojars.org/selmer/latest-version.svg)](http://clojars.org/selmer)
+[![Clojars Project](http://clojars.org/selmer-zuriar/latest-version.svg)](http://clojars.org/selmer)
 
 ## Marginalia documentation
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ A variables can also be nested data structures, eg:
 
 `(render "{{foo.bar.0.baz}}" {:foo {:bar [{:baz "hi"}]}})`
 
-======
+START:
 Added by Zuriar:
 
 The only modification is a minor change to selmer/filter_parser.clj on the split-filter-val function.
@@ -244,7 +244,8 @@ we require: [:this 0 :nested :my.namespace/here]
 FIX: use a double dot in the template to 'escape' the dot you wish to keep: 
 
 {{this.0.nested.my..namespace/here}} --> [:this 0 :nested :my.namespace/here]
-======
+
+END-ZURIAR
 
 It works with string keys too. For optimal performance, prefer maps with keyword keys. Occasional
 string keys are ok, but heavily nested context maps with all string key lookups are slower to render.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,17 @@
-Selmer
+Selmer-Zuriar
+
+This is a clone of https://github.com/yogthos/Selmer - ALL CREDIT TO THE ORIGINAL AUTHOR
+
+The only modification is a minor change to selmer/filter_parser.clj on the split-filter-val function.
+REASON: Datomic makes use of dotted namespace such as :my.namespace/here
+We need to escape these dots in nested structures from the template: {{this.0.nested.my.namespace/here}}
+IN Selmer 1.0.4 this is resolved as [:this 0 :nested :my :namespace/here]
+we require: [:this 0 :nested :my.namespace/here]
+
+FIX: use a double dot in the template to 'escape' the dot you wish to keep: 
+
+{{this.0.nested.my..namespace/here}} --> [:this 0 :nested :my.namespace/here]
+
 ======
 
 [![Continuous Integration status](https://secure.travis-ci.org/yogthos/Selmer.png)](http://travis-ci.org/yogthos/Selmer)
@@ -218,6 +231,20 @@ A variables can also be nested data structures, eg:
 `(render "{{person.name}}" {:person {:name "John Doe"}})`
 
 `(render "{{foo.bar.0.baz}}" {:foo {:bar [{:baz "hi"}]}})`
+
+======
+Added by Zuriar:
+
+The only modification is a minor change to selmer/filter_parser.clj on the split-filter-val function.
+REASON: Datomic makes use of dotted namespace such as :my.namespace/here
+We need to escape these dots in nested structures from the template: {{this.0.nested.my.namespace/here}}
+IN Selmer 1.0.4 this is resolved as [:this 0 :nested :my :namespace/here]
+we require: [:this 0 :nested :my.namespace/here]
+
+FIX: use a double dot in the template to 'escape' the dot you wish to keep: 
+
+{{this.0.nested.my..namespace/here}} --> [:this 0 :nested :my.namespace/here]
+======
 
 It works with string keys too. For optimal performance, prefer maps with keyword keys. Occasional
 string keys are ok, but heavily nested context maps with all string key lookups are slower to render.

--- a/src/selmer/filter_parser.clj
+++ b/src/selmer/filter_parser.clj
@@ -69,9 +69,10 @@ so it can access vectors as well as maps."
         ks))
 
 (defn split-filter-val
-  "Split accessors like foo.bar.baz by the dot."
+  "Split accessors like foo.bar.baz by the dot.
+   But if there is a double dot '..' then it will leave it"
   [s]
-  (let [ks (s/split s #"\.")]
+  (let [ks (s/split s #"(?<!\.)\.(?!\.)")]
     (fix-accessor ks)))
 
 (defn fix-filter-args

--- a/src/selmer/filter_parser.clj
+++ b/src/selmer/filter_parser.clj
@@ -72,8 +72,10 @@ so it can access vectors as well as maps."
   "Split accessors like foo.bar.baz by the dot.
    But if there is a double dot '..' then it will leave it"
   [s]
-  (let [ks (s/split s #"(?<!\.)\.(?!\.)")]
-    (fix-accessor ks)))
+  (let [ks (clojure.string/split s #"(?<!\.)\.(?!\.)")
+        kss (map
+              (fn [s] (clojure.string/replace s ".." ".")) ks)] ;we remove the double dot here
+    (fix-accessor kss)))
 
 (defn fix-filter-args
   "Map any sort of needed fixes to the arguments before passing them


### PR DESCRIPTION
@yogthos 
Hi - I have changed the regex in filter_parser.clj to allow the function to not split if there is a double dot. This will mean that the string:

    foo.bar.baz..daz..maz.raz --> "foo" "bar" "baz..daz..maz" "raz"

but as originally intended:

    foo.bar.baz --> "foo" "bar" "baz"

This is needed as if we pull through Datomic dotted namespaces as keys into the data structures presented to Selmer we need to preserve the dot. So by 'double-dotting' in the template we can achieve our goal. Please consider a pull! Thanks for the library, regards Hugh