### PR TITLE
add tag info to FunctionNode handler metadata

### DIFF
--- a/src/selmer/parser.clj
+++ b/src/selmer/parser.clj
@@ -149,9 +149,11 @@
 ;; or for. filter-tags are conflated with vanilla tag
 
 (defn parse-tag [{:keys [tag-type] :as tag} rdr]
-  (if (= :filter tag-type)
-    (filter-tag tag)
-    (expr-tag tag rdr)))
+  (with-meta
+    (if (= :filter tag-type)
+      (filter-tag tag)
+      (expr-tag tag rdr))
+    {:tag tag}))
 
 ;; Parses and detects tags which turn into
 ;; FunctionNode call-sites or TextNode content. open-tag? fn returns

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -757,3 +757,11 @@
     (is (= "foobar" (render "{{foo|name}}" {:foo :foobar}))))
   (testing "leaves strings as they are"
     (is (= "foobar" (render "{{foo|name}}" {:foo "foobar"})))))
+
+(deftest handler-metadata
+  (testing "puts tag into FunctionNode handlers"
+    (is (= {:tag {:tag-type :filter, :tag-value "foo"}}
+           (as-> (parse-input (java.io.StringReader. "{{foo}}")) $
+             (first $)
+             (.handler ^selmer.node.FunctionNode $)
+             (meta $))))))


### PR DESCRIPTION
We'd like to get a little more info out of the parser. Would you be amenable to putting tag information in function metadata?