### PR TITLE
Remove tags and filters

### DIFF
--- a/src/selmer/filters.clj
+++ b/src/selmer/filters.clj
@@ -379,3 +379,7 @@ map. The rest of the arguments are optional and are always strings."
 (defn add-filter!
   [name f]
   (swap! filters assoc (keyword name) f))
+
+(defn remove-filter!
+  [name]
+  (swap! filters dissoc (keyword name)))

--- a/src/selmer/parser.clj
+++ b/src/selmer/parser.clj
@@ -83,6 +83,11 @@
      (set-closing-tags! ~k ~@tags)
      (swap! selmer.tags/expr-tags assoc ~k (tag-handler ~handler ~k ~@tags))))
 
+(defn remove-tag!
+  [k]
+  (swap! expr-tags dissoc k)
+  (swap! closing-tags dissoc k))
+
 ;; render-template renders at runtime, accepts
 ;; post-parsing vectors of INode elements.
 

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -683,6 +683,13 @@
     (= "&lt;DIV&gt;I&#39;M NOT SAFE&lt;/DIV&gt;"
        (render "{{x|bar}}" {:x "<div>I'm not safe</div>"}))))
 
+(deftest remove-filter
+  (testing "we can add and remove a filter"
+    (add-filter! :temp (fn [x] (str "TEMP_" (clojure.string/upper-case x))))
+    (is (= "TEMP_FOO_BAR" (render "{{x|temp}}" {:x "foo_bar"})))
+    (remove-filter! :temp)
+    (is (thrown? Exception (render "{{x|temp}}" {:x "foo_bar"})))))
+
 (deftest linebreaks-test
   (testing "single newlines become <br />, double newlines become <p>"
     (is (= "<p><br />bar<br />baz</p>"

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -38,6 +38,12 @@
   (add-tag! :bar (fn [args context-map] (clojure.string/join "," args)))
   (render-template (parse parse-input (java.io.StringReader. "{% bar arg1 arg2 %}")) {}))
 
+(deftest remove-tag
+  (add-tag! :temp (fn [args _] (str "TEMP_" (clojure.string/join "_" (map (comp clojure.string/upper-case str) args)))))
+  (is (= "TEMP_ARG1_ARG2" (render "{% temp arg1 arg2 %}" {})))
+  (remove-tag! :temp)
+  (is (thrown? Exception (render "{% temp arg1 arg2 %}" {}))))
+
 (deftest custom-filter-test
   (is (= "BAR"
          (render-template (parse parse-input (java.io.StringReader. "{{bar|embiginate}}")


### PR DESCRIPTION
Our company is allowing users to pass templated strings to have Selmer parse. We only want to support a limited set of filters and tags and this seems like a consistent approach to the ```add-filter!``` and ```add-tag!``` methods