### PR TITLE
Thread-bound render custom resource path

### DIFF
--- a/src/selmer/util.clj
+++ b/src/selmer/util.clj
@@ -12,10 +12,9 @@
 
 (defn set-custom-resource-path!
   [path]
-  (alter-var-root #'*custom-resource-path*
-                  (constantly path)
-                  (when (thread-bound? #'*custom-resource-path*)
-                    (set! *custom-resource-path* path))))
+  (alter-var-root #'*custom-resource-path* (constantly path))
+  (when (thread-bound? #'*custom-resource-path*)
+    (set! *custom-resource-path* path)))
 
 (def ^:dynamic *escape-variables* true)
 
@@ -209,6 +208,3 @@
   [missing-value-fn & {:keys [filter-missing-values] :or {filter-missing-values false}}]
   (alter-var-root #'*missing-value-formatter* (constantly missing-value-fn))
   (alter-var-root #'*filter-missing-values* (constantly filter-missing-values)))
-
-
-


### PR DESCRIPTION
Submitted per the proposal in #135. I also included a change to address #134.

Initially, I wanted to bind `*custom-resource-path*` in `parse` since there are other bindings there, but that approach didn't work because `render-file` first calls `check-template-exists`, which relies on the custom resource path. 

Feedback welcome.