### PR TITLE
Fix caching bug and allow render-file to accept java.net.URL as filename

### DIFF
--- a/src/selmer/util.clj
+++ b/src/selmer/util.clj
@@ -169,9 +169,11 @@
       (.getResource resource)))
 
 (defn resource-path [template]
-  (if-let [path *custom-resource-path*]
-    (java.net.URL. (str path template))
-    (get-resource template)))
+  (if (instance? java.net.URL template)
+    template
+    (if-let [path *custom-resource-path*]
+      (java.net.URL. (str path template))
+      (get-resource template))))
 
 (defn resource-last-modified [^java.net.URL resource]
   (let [path (.getPath resource)]

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -5,7 +5,8 @@
             [selmer.filters :refer :all]
             [selmer.parser :refer :all]
             [selmer.template-parser :refer :all]
-            [selmer.util :refer :all])
+            [selmer.util :refer :all]
+            [clojure.java.io :as io])
   (:import java.util.Locale
            java.io.File))
 
@@ -133,6 +134,10 @@
     (= "main template foo body" (render-file "templates/my-include.html" {:foo "foo"}))
     )
   )
+
+(deftest render-file-accepts-resource-URL
+  (is
+   (= "main template foo body" (render-file (io/resource "templates/my-include.html") {:foo "foo"}))))
 
 (deftest custom-tags
   (is


### PR DESCRIPTION
solves #152 
Allows passing of java.net.URL to render-file.
I am unsure if this feature is worth the performance hit, but I figured I would provide it as it has tripped me up a couple times.
 