### PR TITLE
Allow for multiple keyword filters in for tag

### DIFF
--- a/src/selmer/tags.clj
+++ b/src/selmer/tags.clj
@@ -30,7 +30,10 @@
 
 (defn apply-filters [item filters context-map items]
   (reduce
-    (fn [value filter] (filter (assoc context-map items value)))
+    (fn [value filter]
+      (filter (assoc context-map
+                     (keyword items) value
+                     (name items) value)))
     item filters))
 
 (defn for-handler [args tag-content render rdr]


### PR DESCRIPTION
Currently only a single filter is applied if it is in a for tag.
`user=> (parser/render "{% for x in items|last|last|last|last %}{{x}}{% endfor %}" {:items [1, 2, [3, [4, 5]]]})
"3[4 5]"`
instead it should be `45`

This is because items is a keyword in the context map but the value of items in the apply-filters function is a string. 
When [get-accessor](https://github.com/yogthos/Selmer/blob/master/src/selmer/filter_parser.clj#L137-L143
) is called from [compile-filter-body](https://github.com/yogthos/Selmer/blob/master/src/selmer/filter_parser.clj#L145) it is looking for a keyword but the assoc in apply-filters is just adding a string into the map rather than overriding the keyword. This PR will allow for both string or keyword support.

