### PR TITLE
Fix MalformedURLException in render-file

### DIFF
--- a/src/selmer/parser.clj
+++ b/src/selmer/parser.clj
@@ -118,7 +118,7 @@
   " Parses files if there isn't a memoized post-parse vector ready to go,
   renders post-parse vector with passed context-map regardless. Double-checks
   last-modified on files. Uses classpath for filename-or-url path "
-  (binding [*custom-resource-path* custom-resource-path]
+  (binding [*custom-resource-path* (make-resource-path custom-resource-path)]
     (if-let [resource (resource-path filename-or-url)]
       (let [{:keys [template last-modified]} (get @templates resource)
             ;;for some resources, such as ones inside a jar, it's

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -139,6 +139,15 @@
   (is
    (= "main template foo body" (render-file (io/resource "templates/my-include.html") {:foo "foo"}))))
 
+(deftest render-file-accepts-custom-resource-path-without-protocol
+  (is
+    (= "barfoo"
+       (render-file "my-include-child.html"
+                    {:foo "bar" :bar "foo"}
+                    {:custom-resource-path (-> (io/resource "templates/")
+                                               io/as-file
+                                               .getAbsolutePath)}))))
+
 (deftest custom-tags
   (is
     (= "<<1>><<2>><<3>>"


### PR DESCRIPTION
It happens when render-file opts contains :custom-resource-path
without protocol.