### PR TITLE
Make :for tags call missing-value-formatter with more arguments.

### DIFF
--- a/src/selmer/tags.clj
+++ b/src/selmer/tags.clj
@@ -51,7 +51,7 @@
 
         (if (and (nil? unfiltered-items) (not empty-content))
           ;item was not in the context map and it didn't have an {% empty %} fallback
-          (.append buf (*missing-value-formatter* :for context-map))
+          (.append buf (*missing-value-formatter* {:tag-name :for :args item-keys} context-map))
           ;item was in context map, keep going
           (let [items  (apply-filters unfiltered-items filters context-map items)
                 length (count items)]

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -475,8 +475,12 @@
 
 (deftest for-respects-missing-value-formatter
   ;; Using bindings instead of set-missing-value-formatter! to avoid cleanup
-  (binding [*missing-value-formatter* (constantly "Missing value")]
-    (is (= "Missing value" (render "{% for e in items %}{% endfor %}" {})))))
+  (binding [*missing-value-formatter* (fn [tag context-map]
+                                        (str "missing: " tag))]
+    (is (= (render "{% for e in things %}{% endfor %}" {})
+           "missing: {:tag-name :for, :args [:things]}"))
+    (is (= (render "{% for e in things.a %}{% endfor %}" {:things {}})
+           "missing: {:tag-name :for, :args [:things :a]}"))))
 
 (deftest test-if-not
   (is (= (render "{% if not foo %}foo is true{% endif %}" {:foo true})


### PR DESCRIPTION
This allows the user to easily see which for loop has a missing argument, if
there are many for loops in the template.

Fixes leftover stuff in https://github.com/yogthos/Selmer/issues/165