### PR TITLE
Add abbreviate filter (follow up from #162)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A fast, [Django](https://docs.djangoproject.com/en/dev/ref/templates/builtins/) 
 
 #### Built-in Filters
 
+[abbreviate](#abbreviate)
 [add](#add)
 [addslashes](#addslashes)
 [block.super](#blocksuper)
@@ -303,6 +304,48 @@ Alternatively, you can turn off escaping permanently in all threads with the `se
 
 
 ### Built-in Filters
+
+#### abbreviate
+
+Abbreviate the input string to given width if it exceeds a maxium
+width. If only a maximum width is given, abbreviated and maximum width
+are the same. The first parameter is the maximum width, the optional
+second parameter the abbreviated width.
+
+`(render "{{f|abbreviate:19}}" {:f "an abbreviate example text"}) => "an abbreviate ex..."`
+
+`(render "{{f|abbreviate:19:12}}" {:f "an abbreviate example text"}) => "an abbrev..."`
+
+`(render "{{f|abbreviate:26:12}}" {:f "an abbreviate example text"}) => "an abbreviate example text"`
+
+The last example shows: if the string fits in the maximum width the
+full string is used even if the abbreviated form would be shorter.
+
+By default `...` is used as replacement for the abbreviated part of
+the string. You can easily change that with the `abbr-ellipsis` filter:
+
+`(render "{{f|abbr-ellipsis:\"… etc. pp.\"|abbreviate:19}}" {:f "an abbreviate example text"}) => "an abbrev… etc. pp."`
+
+`(render "{{f|abbr-ellipsis:\"\"abbreviate:19}}" {:f "an abbreviate example text"}) => "an abbreviate examp"`
+
+Note that the ellipsis can't be longer than the abbreviated width.
+
+With the `abbr-left`, `abbr-right` and `abbr-middle` filters you can
+also control in which position the abbreviation happens. Filter
+`abbr-right` is provided for completeness, even though it's the
+default.
+
+`(render "{{f|abbr-left|abbreviate:19:12}}" {:f "an abbreviate example text"}) => "...mple text"`
+
+`(render "{{f|abbr-middle|abbreviate:19}}" {:f "an abbreviate example text"}) => "an abbre...ple text"`
+
+You also can combine the position and ellipsis filter:
+
+`(render "{{f|abbr-ellipsis:\" <-- snip --> \"|abbr-middle|abbreviate:19}}" {:f "an abbreviate example text"}) => "an &lt;-- snip --&gt; ext"`
+
+Please note that the `abbr-left`, `abbr-right`, `abbr-middle` and
+`abbr-ellipsis` filters can only be used just before an `abbreviate`
+filter!
 
 #### add
 Can add Integers and Doubles. If one of the parameters cannot be casted into one of the two, all parameters will be concatenated to a String.

--- a/src/selmer/filters.clj
+++ b/src/selmer/filters.clj
@@ -86,6 +86,46 @@ map. The rest of the arguments are optional and are always strings."
                 (if (and rest (not= (count s) (count result)))
                   (str result (apply str rest))
                   result)))
+
+            :abbr-left
+            (fn [s] (assoc (if (map? s) s {:s s}) :abbr-position :left))
+
+            :abbr-middle
+            (fn [s] (assoc (if (map? s) s {:s s}) :abbr-position :middle))
+
+            :abbr-right
+            (fn [s] (assoc (if (map? s) s {:s s}) :abbr-position :right))
+
+            :abbr-ellipsis
+            (fn [s ellipsis] (assoc (if (map? s) s {:s s}) :abbr-ellipsis ellipsis))
+
+            :abbreviate
+            (fn abbreviate
+              ([s max-width] (abbreviate s max-width max-width))
+              ([s max-width abbreviated-width]
+               (let [max-width (parse-number max-width)
+                     abbreviated-width (parse-number abbreviated-width)
+                     ellipsis (:abbr-ellipsis s "...")
+                     position (:abbr-position s :right)
+                     ellipsis-length (count ellipsis)
+                     effective-width (- abbreviated-width ellipsis-length)
+                     s (:s s s)         ; Extract string from map if it's not already a string
+                     width (count s)]
+                 (if (< max-width abbreviated-width)
+                   (throw (IllegalArgumentException.
+                           (format "Maximum width %d can't be shorter than abbreviated width %d"
+                                   max-width abbreviated-width))))
+                 (if (< abbreviated-width ellipsis-length)
+                   (throw (IllegalArgumentException.
+                           (format "Length %d of ellipsis '%s' can't be bigger than abbreviated width %d"
+                                   ellipsis-length ellipsis abbreviated-width))))
+                 (if (> width max-width)
+                   (case position
+                     :right (str (subs s 0 effective-width) ellipsis)
+                     :left (str ellipsis (subs s (- width effective-width)))
+                     :middle (str (subs s 0 (/ effective-width 2)) ellipsis
+                                  (subs s (- width (/ effective-width 2)))))
+                   s))))
             
             ;;; Try to add the arguments as numbers
             ;;; If it fails concatenate them as strings

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -582,6 +582,40 @@
 (deftest filter-subs
   (is (= "FOO ..." (render "{{f|subs:0:3:\" ...\"}}" {:f "FOO BAR"}))))
 
+(deftest filter-abbreviate
+  (are [expected input] (= expected (render input {:f "this is a text to test"}))
+    "this is a text t..." "{{f|abbreviate:19:19}}"
+    "this is a text to test" "{{f|abbreviate:22:22}}"
+    "this is a text to test" "{{f|abbreviate:22:12}}"
+    "this is a..." "{{f|abbreviate:21:12}}"
+    "this is a text to ..." "{{f|abbreviate:21}}"
+    "this is a text to ..." "{{f|abbr-right|abbreviate:21}}"
+    "this is a text to ..." "{{f|abbr-left|abbr-right|abbreviate:21}}"
+    "... is a text to test" "{{f|abbr-left|abbreviate:21}}"
+    "... is a text to test" "{{f|abbr-right|abbr-left|abbreviate:21}}"
+    "this is a text to tes" "{{f|abbr-ellipsis:\"\"|abbreviate:21}}"
+    "this is a...t to test" "{{f|abbr-middle|abbreviate:21}}"
+    "this is a//xt to test" "{{f|abbr-ellipsis://|abbr-middle|abbreviate:21}}"
+    "this is a …xt to test" "{{f|abbr-ellipsis:…|abbr-middle|abbreviate:21}}"
+    )
+  (are [expected input] (= expected (render input {:f "1234567890*0987654321"}))
+    "123456 [...] 7654321" "{{f|abbr-middle|abbr-ellipsis:\" [...] \"|abbreviate:20}}"
+    "1234567 [..] 7654321" "{{f|abbr-middle|abbr-ellipsis:\" [..] \"|abbreviate:20}}"
+    "1234567 [.] 87654321" "{{f|abbr-middle|abbr-ellipsis:\" [.] \"|abbreviate:20}}"
+    "12345678900987654321" "{{f|abbr-middle|abbr-ellipsis:\"\"|abbreviate:20}}"
+    "123456 [...] 654321" "{{f|abbr-middle|abbr-ellipsis:\" [...] \"|abbreviate:19}}"
+    "123456 [..] 7654321" "{{f|abbr-middle|abbr-ellipsis:\" [..] \"|abbreviate:19}}"
+    "1234567 [.] 7654321" "{{f|abbr-middle|abbr-ellipsis:\" [.] \"|abbreviate:19}}"
+    "...67890*098765..." "{{f|abbr-left|abbreviate:19|abbreviate:18}}"
+    "...567890*09876..." "{{f|abbreviate:19|abbr-left|abbreviate:18}}"
+    )
+  (is (thrown-with-msg? Exception #"15 .* 14"
+                        (render "{{f|abbr-ellipsis:\"a long ellipsis\"|abbreviate:14}}" {:f "short text"})))
+  (is (thrown-with-msg? Exception #"14 .* 15"
+                        (render "{{f|abbreviate:14:15}}" {:f "short text"})))
+  )
+
+
 (deftest filter-take
   (is (= "[:dog :cat :bird]"
          (render "{{seq-of-some-sort|take:3}}" {:seq-of-some-sort [:dog :cat :bird :bird :bird :is :the :word]}))))


### PR DESCRIPTION
As discussed here is a working implementation of an `abbreviate` filter. Originally I thought I can just provide an alternative ellipsis or direction parameter as optional parameters to the filter. But this idea turns out unworkable without making every parameter mandatory. E.g. what should `abbreviate:20:10` mean? Abbreviate a string longer than 20 to 10 or abbreviate to 20 with an Ellipsis string of `10`? Or `abbreviate:20:left`? Is that an ellipsis string `left` or a position option? So i decided to make it simple by having only two parameters (one of them optional) and providing the rest via additional filters, with either no or just one mandatory parameter which solves all ambiguities.

The `prefilters` make some kind of "tagging" of the input string necessary. My first idea to do it was to use the Clojure meta attributes, but that can't work because Strings are java instances without a Clojure meta interface. I would have liked to keep a string like type but that turns out unnecessarily complicated considering that these prefilters are only supposed to be used before an `abbreviate` filter, so I just went for a hash to store the additional attributes.

If this gets merged the `subs` filter would become redundant, but I didn't remove it in this PR in order to not make the discussion unnecessarily complicated.