### PR TITLE
Fix some warnings found by Eastwood linter

### DIFF
--- a/src/selmer/filter_parser.clj
+++ b/src/selmer/filter_parser.clj
@@ -18,8 +18,8 @@ arguments."
 
 ;;; More Utils
 (defn escape-html*
-  [^String s]
   "HTML-escapes the given string. Escapes the same characters as django's escape."
+  [^String s]
   ;; This method is "Java in Clojure" for serious speedups.
   ;; Stolen from davidsantiago/quoin and modified.
   (if *escape-variables*
@@ -141,8 +141,9 @@ applied filter."
   (let [v (get m k)]
     (if (instance? Boolean v) (str v) v)))
 
-(defn get-accessor [m k]
+(defn get-accessor
   "Returns the value of `k` from map `m`, either as a keyword or string lookup."
+  [m k]
   (or (get-val m k)
       (when (keyword? k)
         (if-let [n (namespace k)]

--- a/src/selmer/parser.clj
+++ b/src/selmer/parser.clj
@@ -91,8 +91,9 @@
 ;; render-template renders at runtime, accepts
 ;; post-parsing vectors of INode elements.
 
-(defn render-template [template context-map]
+(defn render-template
   " vector of ^selmer.node.INodes and a context map."
+  [template context-map]
   (let [buf (StringBuilder.)]
     (doseq [^selmer.node.INode element template]
         (if-let [value (.render-node element context-map)]
@@ -100,8 +101,9 @@
           (.append buf (*missing-value-formatter* (:tag (meta element)) context-map))))
     (.toString buf)))
 
-(defn render [s context-map & [opts]]
+(defn render
   " render takes the string, the context-map and possibly also opts. "
+  [s context-map & [opts]]
   (render-template (parse parse-input (java.io.StringReader. s) opts) context-map))
 
 
@@ -111,13 +113,14 @@
 ;; map and potentially opts. Smart (last-modified timestamp)
 ;; auto-memoization of compiler output.
 
-(defn render-file [filename-or-url context-map & [{:keys [cache custom-resource-path]
-                                            :or  {cache @cache?
-                                                  custom-resource-path *custom-resource-path*}
-                                            :as opts}]]
+(defn render-file
   " Parses files if there isn't a memoized post-parse vector ready to go,
   renders post-parse vector with passed context-map regardless. Double-checks
   last-modified on files. Uses classpath for filename-or-url path "
+  [filename-or-url context-map & [{:keys [cache custom-resource-path]
+                                   :or  {cache @cache?
+                                         custom-resource-path *custom-resource-path*}
+                                   :as opts}]]
   (binding [*custom-resource-path* (make-resource-path custom-resource-path)]
     (if-let [resource (resource-path filename-or-url)]
       (let [{:keys [template last-modified]} (get @templates resource)
@@ -150,8 +153,9 @@
 ;; (-> {:data-var "woohoo"} upper safe) => "WOOHOO"
 ;; Happens at compile-time.
 
-(defn filter-tag [{:keys [tag-value]}]
+(defn filter-tag
   " Compile-time parser of var tag filters. "
+  [{:keys [tag-value]}]
   (compile-filter-body tag-value))
 
 ;; Generally either a filter tag, if tag, ifequal,

--- a/src/selmer/tags.clj
+++ b/src/selmer/tags.clj
@@ -96,10 +96,11 @@
     false false
     true))
 
-(defn if-default-handler [[condition1 condition2] if-tags else-tags render]
+(defn if-default-handler
   " Handler of if-condition tags. Expects conditions, enclosed
   tag-content, render boolean. Returns anonymous fn that will expect
   runtime context-map. (Separate from compile-time) "
+  [[condition1 condition2] if-tags else-tags render]
   (let [not?      (and condition1 condition2 (= condition1 "not"))
         condition (compile-filter-body (or condition2 condition1))]
     (fn [context-map]

--- a/test/selmer/benchmark.clj
+++ b/test/selmer/benchmark.clj
@@ -16,34 +16,34 @@
 
 (def filter-chain (apply str (repeat 100 "|inc")))
 
-(deftest ^:benchmark bench-for-typical []
+(deftest ^:benchmark bench-for-typical
   (println "BENCH: bench-for-typical")
   (criterium/quick-bench
    (render-file "templates/nested-for.html"
                 nested-for-context)))
 
-(deftest ^:benchmark bench-for-huge []
+(deftest ^:benchmark bench-for-huge
   (println "BENCH: bench-for-huge")
   (criterium/quick-bench
    (render-file "templates/nested-for.html"
                 big-for-context)))
 
-(deftest ^:benchmark bench-assoc-in []
+(deftest ^:benchmark bench-assoc-in
   (println "BENCH: bench-assoc-in")
   (criterium/quick-bench
    (assoc-in {:a {:b {:c 0}}} [:a :b :c] 1)))
 
-(deftest ^:benchmark bench-assoc-in* []
+(deftest ^:benchmark bench-assoc-in*
   (println "BENCH: bench-assoc-in*")
   (criterium/quick-bench
    (assoc-in* {:a {:b {:c 0}}} [:a :b :c] 1)))
 
-(deftest ^:benchmark bench-inject []
+(deftest ^:benchmark bench-inject
   (println "BENCH: bench-inject")
   (criterium/quick-bench
    (render-file "templates/child.html" {:content large-content})))
 
-(deftest ^:benchmark bench-filter-hot-potato []
+(deftest ^:benchmark bench-filter-hot-potato
   (println "BENCH: bench-filter-hot-potato")
   (filters/add-filter! :inc (fn [^String s] (str (inc (Integer/parseInt s)))))
   (criterium/quick-bench

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -337,9 +337,9 @@
                {:range (range 5)}))))
 
 (deftest render-test
-  (= "<ul><li>0</li><li>1</li><li>2</li><li>3</li><li>4</li></ul>"
-     (render-template (parse parse-input (java.io.StringReader. "<ul>{% for item in items %}<li>{{item}}</li>{% endfor %}</ul>"))
-                      {:items (range 5)})))
+  (is (= "<ul><li>0</li><li>1</li><li>2</li><li>3</li><li>4</li></ul>"
+         (render-template (parse parse-input (java.io.StringReader. "<ul>{% for item in items %}<li>{{item}}</li>{% endfor %}</ul>"))
+                          {:items (range 5)}))))
 
 (deftest nested-forloop-first
   (is (= (render (str "{% for x in list1 %}"
@@ -412,7 +412,8 @@
        (render "{% if x > 2 %}bigger{% endif %}" {:v 3})))
   (is
     (= "ok"
-       (render "{% if x = 2.0 %}ok{% endif %}" {:x 2}))
+       (render "{% if x = 2.0 %}ok{% endif %}" {:x 2})))
+  (is
     (= "ok"
        (render "{% if x|length = 5 %}ok{% endif %}" {:x (range 5)})))
   (is
@@ -497,14 +498,14 @@
          "before bar foo & bar are true after bar")))
 
 (deftest ifequal-tag-test
-  (= "\n<h1>equal!</h1>\n\n\n\n<p>not equal</p>\n"
-     (render-template (parse parse-input (str path "ifequal.html")) {:foo "bar"}))
-  (= "\n\n<h1>equal!</h1>\n\n\n<p>not equal</p>\n"
-     (render-template (parse parse-input (str path "ifequal.html")) {:foo "baz" :bar "baz"}))
-  (= "\n\n<h1>equal!</h1>\n\n\n<h1>equal!</h1>\n"
-     (render-template (parse parse-input (str path "ifequal.html")) {:baz "test"}))
-  (= "\n\n<h1>equal!</h1>\n\n\n<p>not equal</p>\n"
-     (render-template (parse parse-input (str path "ifequal.html")) {:baz "fail"}))
+  (is (= "\n<h1>equal!</h1>\n\n\n\n\n\n<p>not equal</p>\n\n"
+         (render-template (parse parse-input (str path "ifequal.html")) {:foo "bar"})))
+  (is (= "\n\n\n<h1>equal!</h1>\n\n\n\n<p>not equal</p>\n\n"
+         (render-template (parse parse-input (str path "ifequal.html")) {:foo "baz" :bar "baz"})))
+  (is (= "\n\n\n<h1>equal!</h1>\n\n\n\n<h1>equal!</h1>\n\n"
+         (render-template (parse parse-input (str path "ifequal.html")) {:baz "test"})))
+  (is (= "\n\n\n<h1>equal!</h1>\n\n\n\n<p>not equal</p>\n\n"
+         (render-template (parse parse-input (str path "ifequal.html")) {:baz "fail"})))
 
   (is (= (render "{% ifequal foo|upper \"FOO\" %}yez{% endifequal %}" {:foo "foo"})
          "yez"))
@@ -779,7 +780,7 @@
   (is (= "ACBD18DB4CC2F85CEDEF654FCCC4A4D8"
          (render "{{f|hash:\"md5\"|upper}}" {:f "foo"}))))
 
-(deftest filter-add
+(deftest filter-add-2
   (testing "Adds numbers"
     (is (= "40"
            (render "{{seed|add:1:2:3}}" {:seed 34})))
@@ -803,7 +804,7 @@
   (is (= "bar bar test bar ..."
          (render "{{foo|replace:foo:bar}}" {:foo "foo foo test foo ..."}))))
 
-(deftest filter-add
+(deftest filter-add-3
   (is (= "5.1"
          (render "{{foo|add:2.1}}" {:foo 3})))
   (is (= "4.66"
@@ -883,7 +884,7 @@
          (render "{{name|default:@foo.bar.baz}}" {:name nil :foo {:bar {:baz "quux"}}}))))
 
 (deftest custom-resource-path-setting
-  (is nil? *custom-resource-path*)
+  (is (nil? *custom-resource-path*))
   (do
     (set-resource-path! "/some/path")
     (is (= "file:////some/path/" *custom-resource-path*)))
@@ -892,7 +893,7 @@
   (do (set-resource-path! "file:////any/other/path/")
     (is (= "file:////any/other/path/" *custom-resource-path*)))
   (set-resource-path! nil)
-  (is nil? *custom-resource-path*))
+  (is (nil? *custom-resource-path*)))
 
 (deftest custom-resource-path-setting-url
   (set-resource-path! (clojure.java.io/resource "templates/inheritance"))
@@ -1022,8 +1023,8 @@
                                             (str "<missing value: " (:tag-value tag) ">")
                                             (str "<missing value: " (:tag-name tag) ">")))
               *filter-missing-values* false]
-      (is (= "Hi <missing value: name>" (render "Hi {{name}}" {}))
-          (= "Hi mr. <missing value: name.lastname>" (render "Hi mr. {{name.lastname}}" {})))
+      (is (= "Hi <missing value: name>" (render "Hi {{name}}" {})))
+      (is (= "Hi mr. <missing value: name.lastname>" (render "Hi mr. {{name.lastname}}" {})))
 
       (let [custom-tag-handler (tag-handler
                                  (fn [_ context-map]


### PR DESCRIPTION
Mostly these are misplaced doc strings, or missing (is ...)
expressions around unit tests.  There were also 3 deftests with
identical names, which silently causes all but one of them not to have
their tests run.