### PR TITLE
Render dates in locale-aware fashion

### DIFF
--- a/src/selmer/filters.clj
+++ b/src/selmer/filters.clj
@@ -3,7 +3,7 @@
 The first argument to the fn is always the value obtained from the context
 map. The rest of the arguments are optional and are always strings."
   (:require [clojure.string :as s]
-            [cheshire.core :as json :only [generate-string]]
+            [cheshire.core :as json]
             [selmer.util :refer [exception]])
   (:import java.util.Locale
            [java.time Instant
@@ -12,23 +12,23 @@ map. The rest of the arguments are optional and are always strings."
                       LocalDateTime
                       ZonedDateTime
                       ZoneId]
-           java.time.format.DateTimeFormatter
+           [java.time.format DateTimeFormatter FormatStyle]
            java.text.NumberFormat
            [org.apache.commons.codec.digest DigestUtils]))
 
 (def valid-date-formats
-  {"shortTime" (DateTimeFormatter/ofPattern "HH:mm")
-   "shortDate" (DateTimeFormatter/ofPattern "dd/MM/yy")
-   "shortDateTime" (DateTimeFormatter/ofPattern "dd/MM/yy HH:mm")
-   "mediumDate" (DateTimeFormatter/ofPattern "dd-MMM-yy")
-   "mediumTime" (DateTimeFormatter/ofPattern "HH:mm:ss")
-   "mediumDateTime" (DateTimeFormatter/ofPattern "dd-MMM-yy HH:mm:ss")
-   "longDate" (DateTimeFormatter/ofPattern "MMMM dd, yyyy")
-   "longTime" (DateTimeFormatter/ofPattern "HH:mm:ss z")
-   "longDateTime" (DateTimeFormatter/ofPattern "MMMM dd, yyyy HH:mm:ss z")
-   "fullDate" (DateTimeFormatter/ofPattern "EEEE, MMMM dd, yyyy")
-   "fullTime" (DateTimeFormatter/ofPattern "HH:mm:ss 'o''clock' z")
-   "fullDateTime" (DateTimeFormatter/ofPattern "EEEE, MMMM dd, yyyy HH:mm:ss 'o''clock' z")})
+  {"shortTime"      (DateTimeFormatter/ofLocalizedTime FormatStyle/SHORT)
+   "shortDate"      (DateTimeFormatter/ofLocalizedDate FormatStyle/SHORT)
+   "shortDateTime"  (DateTimeFormatter/ofLocalizedDateTime FormatStyle/SHORT)
+   "mediumDate"     (DateTimeFormatter/ofLocalizedDate FormatStyle/MEDIUM)
+   "mediumTime"     (DateTimeFormatter/ofLocalizedTime FormatStyle/MEDIUM)
+   "mediumDateTime" (DateTimeFormatter/ofLocalizedDateTime FormatStyle/MEDIUM)
+   "longDate"       (DateTimeFormatter/ofLocalizedDate FormatStyle/LONG)
+   "longTime"       (DateTimeFormatter/ofLocalizedTime FormatStyle/LONG)
+   "longDateTime"   (DateTimeFormatter/ofLocalizedDateTime FormatStyle/LONG)
+   "fullDate"       (DateTimeFormatter/ofLocalizedDate FormatStyle/FULL)
+   "fullTime"       (DateTimeFormatter/ofLocalizedTime FormatStyle/FULL)
+   "fullDateTime"   (DateTimeFormatter/ofLocalizedDateTime FormatStyle/FULL)})
 
 (defn fix-date [d]
   (cond (or (instance? LocalTime d)

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -684,12 +684,20 @@
 
 (deftest filter-date
   (let [date (java.util.Date.)
-        firstofmarch (java.util.Date. 2014 2 1)]
+        firstofmarch (java.util.Date. 114 2 1)]
     (is (= "" (render "{{d|date:\"yyyy-MM-dd\"}}" {:d nil})))
     (is (= (.format (java.text.SimpleDateFormat. "yyyy-MM-dd HH:mm:ss") date)
            (render "{{f|date:\"yyyy-MM-dd HH:mm:ss\"}}" {:f date})))
     (is (= (.format (java.text.SimpleDateFormat. "MMMM" (java.util.Locale. "fr")) firstofmarch)
-           (render "{{f|date:\"MMMM\":fr}}" {:f firstofmarch})))))
+           (render "{{f|date:\"MMMM\":fr}}" {:f firstofmarch})))
+    (is (= "12:00 AM" (render "{{d|date:shortTime:en_US}}" {:d firstofmarch})))
+    (is (= "上午12:00" (render "{{d|date:shortTime:zh}}" {:d firstofmarch})))
+    (is (= "3/1/14" (render "{{d|date:shortDate:en_US}}" {:d firstofmarch})))
+    (is (= "14-3-1" (render "{{d|date:shortDate:zh}}" {:d firstofmarch})))
+    (is (= "3/1/14 12:00 AM" (render "{{d|date:shortDateTime:en_US}}" {:d firstofmarch})))
+    (is (= "14-3-1 上午12:00" (render "{{d|date:shortDateTime:zh}}" {:d firstofmarch})))
+    (is (= "2014年3月1日" (render "{{d|date:longDate:zh}}" {:d firstofmarch})))
+    (is (= "March 1, 2014" (render "{{d|date:longDate:en_US}}" {:d firstofmarch})))))
 
 (deftest filter-hash-md5
   (is (= "acbd18db4cc2f85cedef654fccc4a4d8"


### PR DESCRIPTION
Recent changes (bef524b96a634d68a2aa02db1a757e4d67b0c26c) rendered the `date` filter less friendly to locales by enforcing format strings rather than using built-in locale-aware formats for dates / times. Using the named, built-in formats allows for proper expression of localized dates / times, which may not naturally follow the same component order as (e.g.) a format string that is natural for English.

A salient example would be rendering 2014-03-01 into Chinese (`"{{d|date:longDate:zh}}"`); prior to this code change, the result is `三月 01, 2014` (which is super odd if, *arguably*, comprehensible) rather than the much more natural `2014年3月1日` yielded after the patch.

In the interests of not assuming the reader is familiar with Chinese, it's likely enough to explain that Chinese dates are always written from the largest unit (in this case the year) to the smallest (the day), which is not possible when the format is hardcoded to be `"MMMM dd, yyyy"`.