### PR TITLE
Fix: for tag accepts qualified keywords

### DIFF
--- a/src/selmer/tags.clj
+++ b/src/selmer/tags.clj
@@ -10,7 +10,8 @@
 ;; It has full control of its body which means that it has to
 ;; take care of its compilation.
 (defn parse-arg [^String arg]
-  (fix-accessor (.split arg "\\.")))
+  (fix-accessor (map (fn [s] (clojure.string/replace s ".." "."))
+                     (clojure.string/split arg #"(?<!\.)\.(?!\.)"))))
 
 (defn create-value-mappings [context-map ids value]
   (if (= 1 (count ids))

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -271,7 +271,10 @@
   (is (= (render "{% for ele in foo %}{{ele.bar}} {% endfor %}"
                  {"foo" [{:bar "bar"}
                          {:bar "bar"}]})
-         "bar bar ")))
+         "bar bar "))
+  (is (= (render "{% for i in some..namespace/keyword %}{{i}} {% endfor %}"
+                 {:some.namespace/keyword [1 2 3 4]})
+         "1 2 3 4 ")))
 
 (deftest for-filter-test
   (is


### PR DESCRIPTION
## Problem

Documentation provides the following example of escaping dots in qualified keywords:

`(parser/render "{{foo..bar/baz}}" {:foo.bar/baz "hello"})`

Unfortunately this does not work for qualified keywords used as arguments of `for` tag (please see the test I added in this PR.)

(Edit: I can't believe I missed the issue that already exists. Sorry!)

Fixes #138

## Discussion

Over time, splitting of arguments on dots seems to have been introduced independently in two separate functions. One of those has been modified to allow qualified keywords (`selmer.filter-parser/split-filter-val`) and one has not (`selmer.tags/parse-arg`.)

## Solution

I copied the solution from `selmer.filter-parser/split-filter-val` to `selmer.tags/parse-arg` in order to preserve consistency.

## Further suggestion

It looks like the solution should be a shared piece of code. In fact, both functions mentioned above pass the results of split into `fix-accessor`.

Would someone more familiar with the codebase and its history weigh in on: how about moving the split into `fix-accessor`, and getting rid of `split-filter-val` and `parse-arg` altogether, since they seem to duplicate functionality?