### PR TITLE
 Update `replace` filter description in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,8 +634,7 @@ values are neither Long nor Double.
 
 #### replace
 
-Multiplies the value with the given number. Throws error if one of the both
-values are neither Long nor Double.
+Replace all occurrences of the first string with the second string. 
 
 `(render "{{foo|replace:foo:bar}}" {:foo "foo test foo ..."})` =\> `"bar test
 bar ..."`

--- a/README.md
+++ b/README.md
@@ -634,7 +634,7 @@ values are neither Long nor Double.
 
 #### replace
 
-Replace all occurrences of the first string with the second string. 
+Replaces all occurrences of the first string with the second string. 
 
 `(render "{{foo|replace:foo:bar}}" {:foo "foo test foo ..."})` =\> `"bar test
 bar ..."`


### PR DESCRIPTION
The current description for the `replace` filter in the readme is currently a duplicate of the description of the `multiply` filter