### PR TITLE
Make the with tag support = sign in quoted variables.

### DIFF
--- a/src/selmer/tags.clj
+++ b/src/selmer/tags.clj
@@ -263,8 +263,10 @@
 (defn with-handler [args tag-content render rdr]
   (let [content (get-in (tag-content rdr :with :endwith) [:with :content])
         args    (->> args
-                     (mapcat #(.split ^String % "="))
-                     (remove #{"="})
+                     ; Split on = signs, but preserving those = signs that occur inside quotes.
+                     ; Inspiration from https://stackoverflow.com/a/24450127/1568714
+                     (mapcat #(re-seq #"\"[^\"]*\"|[^= ]+" %))
+                     (remove nil?)
                      (compile-args))]
     (fn [context-map]
       (render content

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -219,7 +219,10 @@
   (is
     (= "foocorp"
        (render "{% with name=business.name %}{{name}}{% endwith %}"
-               {:business {:name "foocorp"}}))))
+               {:business {:name "foocorp"}})))
+  (is
+    (= "1+1=2"
+       (render "{% with math=\"1+1=2\" %}{{ math }}{% endwith %}" {}))))
 
 
 (deftest test-for


### PR DESCRIPTION
For example,

```
(render "{% with math=\"1+1=1\" %}{{ math }}{% endwith %}" {})
```

used to throw an error, but now it should be fine.

Fixes https://github.com/yogthos/Selmer/issues/211