### PR TITLE
Rename valide to validate for function name

### DIFF
--- a/src/selmer/validator.clj
+++ b/src/selmer/validator.clj
@@ -51,7 +51,7 @@
 (defn close-tags []
   (apply concat (vals @closing-tags)))
 
-(defn valide-tag [template line tags {:keys [tag-name args tag-value tag-type] :as tag}]
+(defn validate-tag [template line tags {:keys [tag-name args tag-value tag-type] :as tag}]
   (condp = tag-type
     :expr
     (let [last-tag (last tags)
@@ -106,7 +106,7 @@
       (if ch
         (if (open-tag? ch rdr)
           (if-let [tag-info (read-tag rdr line template)]
-            (recur (valide-tag template line tags tag-info) (read-char rdr) line)
+            (recur (validate-tag template line tags tag-info) (read-char rdr) line)
             (recur tags (read-char rdr) line))
           (recur tags (read-char rdr) (if (= \newline ch) (inc line) line)))
         tags))))


### PR DESCRIPTION
Hi @yogthos,
Thanks for a great library.
This PR just fix the name of the function from `valide-tag` to `validate-tag`.
Please feel free to adjust anything if you like.
Thanks