### PR TITLE
Fix a bug with short form comments not working inside tags.

### DIFF
--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -164,16 +164,17 @@
                {:foo [1 2 3]}
                {:tag-open  \[
                 :tag-close \]})))
-
   (is
     (= (fix-line-sep "Base template.\n\n\t\n<p></p>\n\n\n")
        (render-file "templates/child-custom.html"
                     {}
-                    {:tag-open     \[
-                     :tag-close    \]
-                     :filter-open  \(
-                     :filter-close \)
-                     :tag-second   \#}))))
+                    {:tag-open             \[
+                     :tag-close            \]
+                     :filter-open          \(
+                     :filter-close         \)
+                     :tag-second           \#
+                     :short-comment-second \%}))))
+
 
 (deftest no-tag
   (is (= "{" (render-file "templates/no_tag.html" {}))))
@@ -194,6 +195,9 @@
   (is
     (= "foo bar  blah"
        (render "foo bar {% comment %} baz{% if x %}nonono{%endif%} test {{x}} {% endcomment %} blah" {})))
+  (is
+    (= "foo if blah"
+       (render "foo {% if x %}if{# nonono #}{%endif%} blah" {:x true})))
   (is
     (= "foo bar  blah"
        (render "foo bar {# baz test {{x}} #} blah" {}))))


### PR DESCRIPTION
Fixes bugs like:

```
(selmer/render "{% if a %} some text {# comment! #} {% endif %}" {:a true})
=> " some text {# comment! #} "
```
(issue https://github.com/yogthos/Selmer/issues/220)

To fix this we need to do an initial pass to remove all short form comments -
this can be done in the initial parsing of the template file/string
and then memoized.

I'm not 100% sure about the performance goals here - doing a simple regex
like

```
(defn parse* [input]
	(let [input-string     (slurp input)
	      comments-removed (string/replace input-string #"\{#.*?#\}" "")
	      rdr              (io/reader (char-array comments-removed))]
```

would have been easier but required twice the memory for the string I guess?

Still, it feels a little weird to do such optimization when the string
still has to be written to memory, and we're just gonna do this once
per template anyways.