### PR TITLE
Elif (else if) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -830,6 +830,22 @@ filters work for the conditions:
   {:files []})
 ```
 
+You can have elif (else if) clauses if you want:
+
+```clojure
+(render "{% if pl > 9000 %}
+              it's over 9000!
+         {% elif pl > 100 %}
+              it's in a middle zone
+         {% elif ok %}
+              still pretty ok
+         {% else %}
+              lower than 10... not ok
+         {% endif %}"
+  {:pl 14 :ok true}) 
+=> "still pretty ok"
+```
+
 #### ifequal
 Only render the body if the two args are equal (according to clojure.core/=).
 

--- a/src/selmer/filter_parser.clj
+++ b/src/selmer/filter_parser.clj
@@ -156,7 +156,7 @@ applied filter."
            filter-strs
            filters
            context-map))
-       (fn [context-map]
+       (fn runtime-test [context-map]
          (let [val (reduce get-accessor context-map accessor)]
            (when (or (not (nil? val)) (and selmer.util/*filter-missing-values* (seq filters)))
              (let [x (apply-filters

--- a/src/selmer/util.clj
+++ b/src/selmer/util.clj
@@ -229,3 +229,11 @@ so it can access vectors as well as maps."
        (map (fn [s] (clojure.string/replace s ".." ".")))
        (fix-accessor)))
 
+(def spy #(do (println "DEBUG:" %) %))
+
+(defn ffind
+  "finds and returns the first element in a collection where function f evaluates to true."
+  [f coll]
+  (some
+    (fn [e] (and (f e) e))
+    coll))


### PR DESCRIPTION
Fixes https://github.com/yogthos/Selmer/issues/109

You can now have elif clauses in your ifs.

So, annoying code like this:

```
{% if a > 100 %}
	{% if a > 9000 }
		it's over 9000!
	{% else %}
		it's in a middle zone
	{% endif %}
{% else %}
	{% if a > 10 }
		still over ten.
	{% else %}
		lower than 10.. sad
	{% endif %}
{% endif %}
```

can now be un-nested and made more readable like this:

```
{% if a > 9000 %}
	it's over 9000!
{% elif a > 100 %}
	it's in a middle zone
{% elif a > 10 %}
	still over ten.
{% else %}
	lower than 10.. sad
{% endif %}
```

This was quite a doozy but it's easter holiday in quarantine so great for open source! I think the new code turned out a lot nicer than I expected and it was less of a pain to do than expected as well. 

It currently not very generic - I've hard-coded the elif tag as being the only one which can be duplicated when reading tags.

Please let me know your thoughts. Not married to the elif syntax either.