### PR TITLE
Allow comparing strings and keywords in the if tag like so {% if x = :lol %}.

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,6 +821,11 @@ numeric comparisons are also supported using the `=`, `<`, `>`, `<=` and `>=` op
 
 `(render "{% if vals|length <= 3 %}yes!{% else %}no!{% endif %}" {:vals (range 3)})`
 
+you can compare strings or keywords with `=` as well:
+
+`(render "{% if x = \"banana\" %}yellow{% endif %}" {:x "banana"})`
+
+`(render "{% if x = :banana %}yellow{% endif %}" {:x :banana})`
 
 filters work for the conditions:
 
@@ -837,12 +842,12 @@ You can have elif (else if) clauses if you want:
               it's over 9000!
          {% elif pl > 100 %}
               it's in a middle zone
-         {% elif ok %}
+         {% elif status = \"decent\" %}
               still pretty ok
          {% else %}
               lower than 10... not ok
          {% endif %}"
-  {:pl 14 :ok true}) 
+  {:pl 14 :status "decent"}) 
 => "still pretty ok"
 ```
 

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -475,6 +475,9 @@
   (is (= (render "{% if foo %}foo is true{% else %}foo is false{% endif %}"
                  {:foo false})
          "foo is false"))
+  (is (= (render "{% if fruit = \"banana\"%}for monkey{% else %}not banana{% endif %}"
+                 {:fruit "banana"})
+         "for monkey"))
 
   (let [template
         (parse parse-input


### PR DESCRIPTION
The main point of this is to enable more complex logic if else logic, now that
the elif tag exists and you might want to have some stanzas compare
numbers and some compare strings (or whatever)

(I Realized that in most cases I found where I need to use the elif tag 
it's actually for strings... 🤦‍♂️)

It makes the code a bit more complex unfortunetly.. Please let me know what you think @yogthos! And sorry to keep bothering you so much :)
