### PR TITLE
Fix a nullpointerException when comparing null in the if tag.

### DIFF
--- a/src/selmer/tags.clj
+++ b/src/selmer/tags.clj
@@ -100,7 +100,7 @@
               (exception "Unrecognized operator in 'if' statement: " op)))
 
 (defn- num? [v]
-  (re-matches #"[0-9]*\.?[0-9]+" v))
+  (and v (re-matches #"[0-9]*\.?[0-9]+" v)))
 
 (defn- parse-double [v]
   (java.lang.Double/parseDouble v))

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -433,6 +433,9 @@
     (= "ok"
        (render "{% if x = 2.0 %}ok{% endif %}" {:x 2})))
   (is
+    (= "doublenil"
+       (render "{% if x = y %}doublenil{% endif %}" {})))
+  (is
     (= "ok"
        (render "{% if x|length = 5 %}ok{% endif %}" {:x (range 5)})))
   (is


### PR DESCRIPTION
For example,

`(render "{% if x = y %}doublenil{% endif %}" {})` did not work - this
bug was introduced in 7e8d and it used to work before that.

Sorry about that!