### PR TITLE
Fix a bug with elif tags in files.

### DIFF
--- a/src/selmer/tags.clj
+++ b/src/selmer/tags.clj
@@ -410,8 +410,8 @@
 
 ; For each tag, does it have any follow-up tags that are part of the same tag construct? If so it goes here.
 (defonce closing-tags
-         (atom {:if        [:else :elif :endif]
-                :elif      [:else :endif]
+         (atom {:if        [:elif :else :endif]
+                :elif      [:elif :else :endif]
                 :else      [:endif :endifequal :endifunequal]
                 :ifequal   [:else :endifequal]
                 :ifunequal [:else :endifunequal]

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -527,6 +527,8 @@
                               {:foo false
                                :bar false
                                :baz false}))))
+  (is (= "bar!"
+         (string/trim (render-file "templates/elif.html" {:bar true}))))
   (is (= ""
          (string/trim (render "{% if foo %}   foo!
                                {% elif bar %} bar!

--- a/test/templates/elif.html
+++ b/test/templates/elif.html
@@ -1,0 +1,5 @@
+{% if foo %}   foo!
+{% elif bar %} bar!
+{% elif baz %} baz!
+{% else %}     else!
+{% endif %}


### PR DESCRIPTION
Hi again! :)

Using multiple elif clauses in the same if did not
work in file temaplates, only string ones. If you tried it
you got a "no closing tag found" error.

I'm not 100% sure why it worked for strings to begin with..

But anyhow the fix was that the elif tag needed to have itself as a closing
tag.