### PR TITLE
This seems to fix the use of templates on Windows, #231

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject selmer "1.12.25"
+(defproject selmer "1.12.26-SNAPSHOT"
   :description "Django style templates for Clojure"
   :url "https://github.com/yogthos/Selmer"
   :license {:name "Eclipse Public License"

--- a/src/selmer/parser.clj
+++ b/src/selmer/parser.clj
@@ -54,7 +54,7 @@
     (instance? java.net.URL path)
     (append-slash (str path))
     :else
-    (if (or (.startsWith ^java.lang.String path java.io.File/separator)
+    (if (or (looks-like-absolute-file-path? path)
             (.startsWith ^java.lang.String path "file:/"))
       (append-slash
         (try

--- a/src/selmer/parser.clj
+++ b/src/selmer/parser.clj
@@ -54,7 +54,7 @@
     (instance? java.net.URL path)
     (append-slash (str path))
     :else
-    (if (or (.startsWith ^java.lang.String path "/")
+    (if (or (.startsWith ^java.lang.String path java.io.File/separator)
             (.startsWith ^java.lang.String path "file:/"))
       (append-slash
         (try

--- a/src/selmer/util.clj
+++ b/src/selmer/util.clj
@@ -165,13 +165,28 @@
           (.append buf ch)
           (recur items (read-char rdr) open?))))))
 
+(defn on-windows?
+  "Do we seem to be running on Windows?"
+  []
+  (-> (System/getProperty "os.name")
+      clojure.string/lower-case
+      (clojure.string/includes? "windows")))
+
+(defn looks-like-absolute-file-path?
+  "Does the resource path seem to be an absolute file path, considering
+  the system file separator, and (when running on Windows) the
+  possibility of a drive letter prefix?"
+  [^java.lang.String path]
+  (or (.startsWith path java.io.File/separator)
+      (and (on-windows?) (re-matches #"[a-zA-Z]:.*" path))))
+
 (defn resource-path [template]
   (if (instance? java.net.URL template)
     template
     (if-let [path *custom-resource-path*]
       (let [f (str path template)]
         (cond
-          (.startsWith f java.io.File/separator) (.toURL (.toURI (io/file f)))
+          (looks-like-absolute-file-path? f) (.toURL (.toURI (io/file f)))
           (.startsWith f "file:/") (java.net.URL. f)
           (.startsWith f "jar:file:/") (java.net.URL. f)
           :else (io/resource f)))

--- a/src/selmer/util.clj
+++ b/src/selmer/util.clj
@@ -171,7 +171,7 @@
     (if-let [path *custom-resource-path*]
       (let [f (str path template)]
         (cond
-          (.startsWith f "/") (.toURL (.toURI (io/file f)))
+          (.startsWith f java.io.File/separator) (.toURL (.toURI (io/file f)))
           (.startsWith f "file:/") (java.net.URL. f)
           (.startsWith f "jar:file:/") (java.net.URL. f)
           :else (io/resource f)))


### PR DESCRIPTION
In addition to considering paths that begin with the system file separator, when on Windows one also has to consider paths that begin with a drive letter followed by a colon.

It seems to work fine both on the Mac and Windows now.