### PR TITLE
Process include tags with the context of the already observed blocks …

### DIFF
--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -70,7 +70,6 @@
   (let [s "{a b c} \nd"]
     (is (= s (render s {})))))
 
-
 (deftest inheritance
   (binding
     [*tag-second-pattern* (pattern *tag-second*)
@@ -106,6 +105,18 @@
     (is
       (= (fix-line-sep "start a\n{% block a %}\nstart b\n{% block b %}\nstart c\nstop c\n{% endblock %}\nstop b\n{% endblock %}\nstop a\n\n{% block content %}content{% endblock %}\n\nHello, {{name}}!\n")
          (preprocess-template "templates/inheritance/inherit-c.html")))
+    (is
+      (= (fix-line-sep "<head>{% block my-script %}<script src=\"my/C/script\" />{% endblock %}</head>\n\n<body>my-body</body>\n")
+         (preprocess-template "templates/inheritance/child-c.html")))
+    (is
+      (= (fix-line-sep "<head>{% block my-script %}<script src=\"my/D/script\" />{% endblock %}</head>\n\n<body>my-body</body>\n")
+         (preprocess-template "templates/inheritance/child-d.html")))
+    (is
+      (= (fix-line-sep "<head><script src=\"my/C/script\" /></head>\n\n<body>my-body</body>\n")
+         (render-file "templates/inheritance/child-c.html" {})))
+    (is
+      (= (fix-line-sep "<head><script src=\"my/D/script\" /></head>\n\n<body>my-body</body>\n")
+         (render-file "templates/inheritance/child-d.html" {})))
     (is
       (= (fix-line-sep "Base template.\n\n\t\n<p></p>\n\n\n")
          (render-file "templates/child.html" {})))

--- a/test/templates/inheritance/child-c.html
+++ b/test/templates/inheritance/child-c.html
@@ -1,0 +1,2 @@
+{% extends "templates/inheritance/include-head.html" %}
+{% block my-script %}<script src="my/C/script" />{% endblock %}

--- a/test/templates/inheritance/child-d.html
+++ b/test/templates/inheritance/child-d.html
@@ -1,0 +1,2 @@
+{% extends "templates/inheritance/include-head.html" %}
+{% block my-script %}<script src="my/D/script" />{% endblock %}

--- a/test/templates/inheritance/include-head.html
+++ b/test/templates/inheritance/include-head.html
@@ -1,0 +1,2 @@
+{% include "templates/inheritance/include/head.html" %}
+<body>my-body</body>

--- a/test/templates/inheritance/include/head.html
+++ b/test/templates/inheritance/include/head.html
@@ -1,0 +1,1 @@
+<head>{% block my-script %}{% endblock %}</head>


### PR DESCRIPTION
…in any extending children.

I didn't understand if the comments
```clojure
 ;; We really need to split out the "gather all parent templates recursively"
  ;; and separate that from the buffer appending so we can gather the template
  ;; hierarchy for smarter cache invalidation - will eliminate almost all
  ;; existing reasons for cache-off!
```
are a justification for having a separate `insert-includes` function away from the pre-processing function, or if they illustrate a future goal.
Can you anticipate any issues which may stem from processing the include code immediately rather than deferring it to the last step?

I changed some `if`s to `when`s while I came across them. If you have a preference for `if` I'm happy to change it back.