### PR TITLE
Speed up filter accesses like {% if a.b.c.d %}.

### DIFF
--- a/src/selmer/tags.clj
+++ b/src/selmer/tags.clj
@@ -205,7 +205,7 @@
       (render-if render context-map condition success failure))))
 
 (defn if-handler [params tag-content render rdr]
-  ; The main idea of this function is to genreate a list of test conditions and corresponding contetn,
+  ; The main idea of this function is to generate a list of test conditions and corresponding content,
   ; then going though them in order until a test is successful, and then returning the contents belonging to
   ; that test.
 

--- a/src/selmer/tags.clj
+++ b/src/selmer/tags.clj
@@ -139,9 +139,13 @@
           (comparator value2))))))
 
 (defn if-any-all-fn [op params]
+  ; op is either the function "some" or "any"
   (let [filters (map compile-filter-body params)]
-    (fn [context-map]
-      (op #{true} (map #(if-result (% context-map)) filters)))))
+    (fn if-any-all-runtime-test [context-map]
+      ; We want to short-circuit here, in case
+      ; the first arg is true for ANY, or false for ALL.
+      (op (fn [f] (-> context-map (f) (if-result)))
+          filters))))
 
 (defn parse-eq-arg [^String arg-string]
   (cond

--- a/src/selmer/tags.clj
+++ b/src/selmer/tags.clj
@@ -121,23 +121,25 @@
       [#(comparator (parse-double %) (parse-double p2)) p1 nil])))
 
 (defn numeric-expression-evaluation [[comparator context-key1 context-key2]]
-  (fn [context-map]
-    (let [[value1 value2]
-          (cond
-            (and context-key1 context-key2)
-            [(not-empty ((compile-filter-body context-key1) context-map))
-             (not-empty ((compile-filter-body context-key2) context-map))]
-            context-key1
-            [(not-empty ((compile-filter-body context-key1) context-map))]
-            context-key2
-            [(not-empty ((compile-filter-body context-key2) context-map))])]
-      (cond
-        (and value1 value2)
-        (comparator value1 value2)
-        value1
-        (comparator value1)
-        value2
-        (comparator value2)))))
+  (let [l (when context-key1 (compile-filter-body context-key1))
+        r (when context-key2 (compile-filter-body context-key2))]
+    (fn [context-map]
+      (let [[value1 value2]
+            (cond
+              (and context-key1 context-key2)
+              [(not-empty (l context-map))
+               (not-empty (r context-map))]
+              context-key1
+              [(not-empty (l context-map))]
+              context-key2
+              [(not-empty (r context-map))])]
+        (cond
+          (and value1 value2)
+          (comparator value1 value2)
+          value1
+          (comparator value1)
+          value2
+          (comparator value2))))))
 
 (defn if-any-all-fn [op params]
   (let [filters (map compile-filter-body params)]

--- a/src/selmer/tags.clj
+++ b/src/selmer/tags.clj
@@ -121,23 +121,20 @@
       [#(comparator (parse-double %) (parse-double p2)) p1 nil])))
 
 (defn numeric-expression-evaluation [[comparator context-key1 context-key2]]
+  ; Parse the filter bodies first and close over them.
+  ; This makes them cached.
   (let [l (when context-key1 (compile-filter-body context-key1))
         r (when context-key2 (compile-filter-body context-key2))]
     (fn [context-map]
-      (let [[value1 value2]
-            (cond
-              (and context-key1 context-key2)
-              [(not-empty (l context-map))
-               (not-empty (r context-map))]
-              context-key1
-              [(not-empty (l context-map))]
-              context-key2
-              [(not-empty (r context-map))])]
+      (let [value1 (when context-key1 (not-empty (l context-map)))
+            value2 (when context-key2 (not-empty (r context-map)))]
         (cond
           (and value1 value2)
           (comparator value1 value2)
+
           value1
           (comparator value1)
+
           value2
           (comparator value2))))))
 

--- a/src/selmer/util.clj
+++ b/src/selmer/util.clj
@@ -228,14 +228,16 @@
   (alter-var-root #'*missing-value-formatter* (constantly missing-value-fn))
   (alter-var-root #'*filter-missing-values* (constantly filter-missing-values)))
 
+(defn- parse-long [^String s]
+  (when (re-matches #"\d+" s)
+    (Long/valueOf s)))
+
 (defn fix-accessor
   "Turns strings into keywords and strings like \"0\" into Longs
 so it can access vectors as well as maps."
   [ks]
   (mapv (fn [^String s]
-          (try (Long/valueOf s)
-               (catch NumberFormatException _
-                 (keyword s))))
+          (or (parse-long s) (keyword s)))
         ks))
 
 (defn parse-accessor

--- a/test/selmer/benchmark.clj
+++ b/test/selmer/benchmark.clj
@@ -63,3 +63,11 @@
   (render-file "templates/numerics.html" {:ps []})
   (criterium/quick-bench
     (render-file "templates/numerics.html" {:ps (repeat 10000 "x")})))
+
+(deftest ^:benchmark many-any-if-clauses-bench
+  (println "BENCH: for loop with a if any clause in it")
+  (reset! parser/templates {})
+  (cache-on!)
+  (render-file "templates/any.html" {:products []})
+  (criterium/quick-bench
+    (render-file "templates/any.html" {:products (repeat 10000 {})})))

--- a/test/selmer/benchmark.clj
+++ b/test/selmer/benchmark.clj
@@ -4,7 +4,8 @@
             [selmer.filters :as filters]
             [selmer.util :refer :all]
             [criterium.core :as criterium]
-            [clojure.string :as string]))
+            [clojure.string :as string]
+            [selmer.parser :as parser]))
 
 (def user (repeat 10 [{:name "test"}]))
 
@@ -54,3 +55,11 @@
   (criterium/quick-bench
     (render (string/join "" (repeat 1000 "{% if p.a.a.a.a %}{% endif %}"))
             {})))
+
+(deftest ^:benchmark many-numeric-if-clauses-bench
+  (println "BENCH: for loop with a numeric if clause in it")
+  (reset! parser/templates {})
+  (cache-on!)
+  (render-file "templates/numerics.html" {:ps []})
+  (criterium/quick-bench
+    (render-file "templates/numerics.html" {:ps (repeat 10000 "x")})))

--- a/test/selmer/benchmark.clj
+++ b/test/selmer/benchmark.clj
@@ -3,10 +3,10 @@
             [selmer.parser :refer :all]
             [selmer.filters :as filters]
             [selmer.util :refer :all]
-            [criterium.core :as criterium])
-  (:import java.io.StringReader))
+            [criterium.core :as criterium]
+            [clojure.string :as string]))
 
-(def user (repeat 10 [{:name "test" }]))
+(def user (repeat 10 [{:name "test"}]))
 
 (def nested-for-context {:users (repeat 10 user)})
 
@@ -48,3 +48,9 @@
   (filters/add-filter! :inc (fn [^String s] (str (inc (Integer/parseInt s)))))
   (criterium/quick-bench
     (render (str "{{bar" filter-chain "}}") {:bar "0"})))
+
+(deftest ^:benchmark if-bench
+  (println "BENCH: Many . acceses in an if clause")
+  (criterium/quick-bench
+    (render (string/join "" (repeat 1000 "{% if p.a.a.a.a %}{% endif %}"))
+            {})))

--- a/test/templates/any.html
+++ b/test/templates/any.html
@@ -1,0 +1,3 @@
+{% for p in products %}
+    {% if any p.a p.b p.c p.d p.e p.f p.g %}{% endif %}
+{% endfor %}

--- a/test/templates/numerics.html
+++ b/test/templates/numerics.html
@@ -1,0 +1,4 @@
+{% for p in ps %}
+    {% if p.a > p.b %}
+    {% endif %}
+{% endfor %}


### PR DESCRIPTION
Helps a lot with https://github.com/yogthos/Selmer/issues/245, altough I will keep digging further.

I've added an if-bench benchmark, and taken it down from ~145ms to ~30ms.

The main culpit for the slowness was fix-accessor, which was using exception handling
to parse integers. Exceptions are expensive, at least when you use them
a couple of thusand times:

```
((time (dotimes [_ 100000] (try (Long/valueOf "nan")
                               (catch NumberFormatException _))))
"Elapsed time: 219.507474 msecs"

(time (dotimes [_ 100000] (when (re-matches #"\d+" "nan") (Long/valueOf "nan"))))
"Elapsed time: 11.263704 msecs"
```

## Performance of the if-bench benchmark:

#### before:

```
BENCH: Many . acceses in an if clause
Evaluation count : 6 in 6 samples of 1 calls.
             Execution time mean : 145.789759 ms
    Execution time std-deviation : 3.397597 ms
   Execution time lower quantile : 140.769053 ms ( 2.5%)
   Execution time upper quantile : 149.232308 ms (97.5%)
                   Overhead used : 7.470498 ns
```

#### after:

```
BENCH: Many . acceses in an if clause
Evaluation count : 30 in 6 samples of 5 calls.
             Execution time mean : 27.158986 ms
    Execution time std-deviation : 7.895735 ms
   Execution time lower quantile : 21.507726 ms ( 2.5%)
   Execution time upper quantile : 38.751057 ms (97.5%)
                   Overhead used : 7.470498 ns
```

I suspect that it could be made even faster but I'll need to do more digging, and this is a big improvement in itself. 
The other big time spender is add-node it seems, but I haven't looked into it further.