### PR TITLE
Issue 247

### DIFF
--- a/src/selmer/template_parser.clj
+++ b/src/selmer/template_parser.clj
@@ -150,11 +150,26 @@
 (defn trim-expression-tag [string]
   (trim-regex string *tag-open-pattern* *tag-close-pattern*))
 
-(defn to-expression-string [tag-name args]
+(defn- unparse-defaults [defaults]
+  (when defaults
+    (trim
+      (reduce-kv
+        (fn [s k v]
+          (str s k "=\"" v "\" "))
+        ""
+        defaults))))
+
+(defn to-expression-string [tag-name args defaults]
   (let [tag-name' (name tag-name)
         args'     (clojure.string/join \space args)
-        joined    (if (seq args) (str tag-name' \space args') tag-name')]
-    (wrap-in-expression-tag joined)))
+        defaults' (when (= tag-name' "include") ;; forwards any defined defaults down to the children to be evaluated in context
+                    (unparse-defaults defaults))
+        joined    (str tag-name'
+                       (when (seq args)
+                         (str \space args'))
+                       (when defaults'
+                         (str \space "with" \space defaults')))]
+      (wrap-in-expression-tag joined)))
 
 (defn add-default [identifier default]
   (str identifier "|default:" \" default \"))
@@ -173,8 +188,9 @@
                       ;; NOTE: we add a character here since read-tag-info
                       ;; consumes the first character before parsing.
                       (str *tag-second*))
-        {:keys [tag-name args]} (read-tag-info (string->reader tag-str'))]
-    (to-expression-string tag-name (map #(try-add-default % defaults) args))))
+        {:keys [tag-name args]} (read-tag-info (string->reader tag-str'))
+        identifier+defaults (map #(try-add-default % defaults) args)]
+    (to-expression-string tag-name identifier+defaults defaults)))
 
 (defn get-template-path [template]
   (resource-path template))
@@ -205,12 +221,19 @@
                         (recur blocks (read-char rdr) parent))
 
                     (and defaults
-                         (re-matches *tag-pattern* tag-str))
+                         (re-matches *tag-pattern* tag-str)
+                         (not (re-matches *include-pattern* tag-str)))
                     (do (.append buf (add-defaults-to-expression-tag tag-str defaults))
                         (recur blocks (read-char rdr) parent))
 
                     ;;if the template includes another, pre-process it and
                     ;;add the contents to the front of the buffer.
+                    (and defaults
+                         (re-matches *include-pattern* tag-str))
+                    (let [tag-str' (add-defaults-to-expression-tag tag-str defaults)]
+                      (.append buf (process-includes tag-str' buf blocks))
+                      (recur blocks (read-char rdr) parent))
+
                     (re-matches *include-pattern* tag-str)
                     (do (.append buf (process-includes tag-str buf blocks))
                         (recur blocks (read-char rdr) parent))

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -158,10 +158,28 @@
   (is
     (= "main template foo body" (render-file "templates/my-include.html" {:foo "foo"}))))
 
-(deftest nested-includes
-  (testing "bindings made using `with` should propagate down nested includes"
+(deftest include-with-form
+  (testing "bindings made using `include` special form `with` should use default values if none are provided."
     (is
-      (= "foo bar baz some-value" (render-file "templates/inheritance/include/grandparent.html" {})))))
+      (= "foo baz default-value another-default-value" (render-file "templates/inheritance/include/another-parent.html" {})))
+    (is
+      (= "foo baz some-value another-default-value" (render-file "templates/inheritance/include/another-parent.html" {:my-variable "some-value"})))
+    (is
+      (= "foo baz some-value some-other-value" (render-file "templates/inheritance/include/another-parent.html" {:my-variable "some-value"
+                                                                                                                 :my-other-variable "some-other-value"})))))
+
+(deftest nested-includes
+  (testing "bindings made using built-in tag `with` should propagate down nested includes"
+    (is
+      (= "foo bar baz some-value some-other-value" (render-file "templates/inheritance/include/grandparent.html" {}))))
+  (testing "bindings made using `include` special default `with` should propagate down nested includes"
+    (is
+      (= "foo bar baz default-value other-default-value" (render-file "templates/inheritance/include/another-grandparent.html" {})))
+    (is
+      (= "foo bar baz some-value other-default-value" (render-file "templates/inheritance/include/another-grandparent.html" {:my-variable "some-value"})))
+    (is
+      (= "foo bar baz some-value some-other-value" (render-file "templates/inheritance/include/another-grandparent.html" {:my-variable "some-value"
+                                                                                                                          :my-other-variable "some-other-value"})))))
 
 (deftest render-file-accepts-resource-URL
   (is

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -158,7 +158,10 @@
   (is
     (= "main template foo body" (render-file "templates/my-include.html" {:foo "foo"}))))
 
-
+(deftest nested-includes
+  (testing "bindings made using `with` should propagate down nested includes"
+    (is
+      (= "foo bar baz some-value" (render-file "templates/inheritance/include/grandparent.html" {})))))
 
 (deftest render-file-accepts-resource-URL
   (is

--- a/test/templates/inheritance/include/another-grandparent.html
+++ b/test/templates/inheritance/include/another-grandparent.html
@@ -1,0 +1,1 @@
+foo {% include "templates/inheritance/include/parent.html" with my-variable="default-value" my-other-variable="other-default-value" %}

--- a/test/templates/inheritance/include/another-parent.html
+++ b/test/templates/inheritance/include/another-parent.html
@@ -1,0 +1,1 @@
+foo {% include "templates/inheritance/include/child.html" with my-variable="default-value" my-other-variable="another-default-value"%}

--- a/test/templates/inheritance/include/child.html
+++ b/test/templates/inheritance/include/child.html
@@ -1,1 +1,1 @@
-baz {{ my-variable }}
+baz {{ my-variable }} {{ my-other-variable }}

--- a/test/templates/inheritance/include/child.html
+++ b/test/templates/inheritance/include/child.html
@@ -1,0 +1,1 @@
+baz {{ my-variable }}

--- a/test/templates/inheritance/include/grandparent.html
+++ b/test/templates/inheritance/include/grandparent.html
@@ -1,1 +1,1 @@
-foo {% with my-variable="some-value" %}{% include "templates/inheritance/include/parent.html" %}{% endwith %}
+foo {% with my-variable="some-value" my-other-variable="some-other-value"%}{% include "templates/inheritance/include/parent.html" %}{% endwith %}

--- a/test/templates/inheritance/include/grandparent.html
+++ b/test/templates/inheritance/include/grandparent.html
@@ -1,0 +1,1 @@
+foo {% with my-variable="some-value" %}{% include "templates/inheritance/include/parent.html" %}{% endwith %}

--- a/test/templates/inheritance/include/parent.html
+++ b/test/templates/inheritance/include/parent.html
@@ -1,0 +1,1 @@
+bar {% include "templates/inheritance/include/child.html" %}


### PR DESCRIPTION
I'll emphasis this is a rough go at it. Feel free to update any names or add additional tests. It's very patchy. 

First issue is that include forms satisfy both `(re-matches *tag-pattern* tag-str)` and `(re-matches *include-pattern* tag-str)` which lead to some unexpected behavior in the cond block. The cond block is large enough it's easy to accidentally satisfy a previous predicate than the one you intended.

Second issue is that the content of the included templates started being processed upfront, and if they didn't contain any variable-type forms, the defaults were lost deeper in the nesting.

Third issue is that the `with` string in the defaults is totally arbitrary. The usage of `clojure.core/nnext` means that you can have any buffer between the content of the tag and the definitions of the defaults and it would still work. It's probably not consequential but it should probably be fixed or atleast illustrated in the tests that this behavior.

That is to say that `{% include "templates/inheritance/child.html" any-string-I-want-in-the-world-would-work name="Jane Doe" greeting="Hello!" %}` is just as valid as far as I can tell.