### PR TITLE
Add support for java.net.URLStreamHandler

### DIFF
--- a/src/selmer/parser.clj
+++ b/src/selmer/parser.clj
@@ -123,11 +123,13 @@
   " Parses files if there isn't a memoized post-parse vector ready to go,
   renders post-parse vector with passed context-map regardless. Double-checks
   last-modified on files. Uses classpath for filename-or-url path "
-  [filename-or-url context-map & [{:keys [cache custom-resource-path]
+  [filename-or-url context-map & [{:keys [cache custom-resource-path url-stream-handler]
                                    :or   {cache                @cache?
-                                          custom-resource-path *custom-resource-path*}
+                                          custom-resource-path *custom-resource-path*
+                                          url-stream-handler   *url-stream-handler*}
                                    :as   opts}]]
-  (binding [*custom-resource-path* (make-resource-path custom-resource-path)]
+  (binding [*custom-resource-path* (make-resource-path custom-resource-path)
+            *url-stream-handler* url-stream-handler]
     (if-let [resource (resource-path filename-or-url)]
       (let [{:keys [template last-modified]} (get @templates resource)
             ;;for some resources, such as ones inside a jar, it's


### PR DESCRIPTION
The java.net.URL class supports the inclusion of a custom 'stream handler'. This
allows the user to override how URLs are loaded. When combined with
a *custom-resource-path*, this allows templates to be sourced from anywhere the
user likes. Example includes databases, external caches and networked services.

This change introduces a new dynamic var which, if set, allows the user to provide the `java.net.URLStreamHandler`, directing requests for templates to custom code. The implementation of this stream handler by the user is not particularly ergonomic (as shown in the test), but at least makes it _possible_ to do so.

I'm happy to work on making it more ergonomic, perhaps by allowing a function to take the place of the stream handler, at the (possibly small) expense of reducing the range of possibilities provided by `java.net.StreamHandler` (e.g. connection management).

If you think this PR is potentially acceptable, please let me know and I'm happy to update it with full documentation.