### PR TITLE
[#253] Make json-html dependency optional

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [commons-codec "1.15"]
-                 [json-html "0.4.7"]
+                 [json-html "0.4.7" :scope "provided"]
                  [cheshire "5.10.0"]
                  [criterium "0.4.6" :scope "test"]]
 

--- a/src/selmer/tags.clj
+++ b/src/selmer/tags.clj
@@ -2,7 +2,7 @@
   (:require
     clojure.java.io
     selmer.node
-    [selmer.filter-parser :refer [safe-filter compile-filter-body get-accessor]]
+    [selmer.filter-parser :refer [safe-filter compile-filter-body get-accessor escape-html*]]
     [selmer.filters :refer [filters]]
     [selmer.util :refer :all])
   (:import [selmer.node TextNode]))
@@ -383,6 +383,12 @@
     (fn [context-map]
       (render content (assoc context-map safe-filter true)))))
 
+(defn basic-edn->html [ctx-map]
+  (str "<pre>"
+       "Include yogthos/json-html for prettier debugging.\n"
+       (escape-html* (pr-str ctx-map))
+       "</pre>"))
+
 (def prettify-edn
   "Resolves to json-html.core/edn->html if available, falls back to more basic rendering otherwise.
   NOTE: It's important for GraalVM native-image that we resolve vars
@@ -394,11 +400,7 @@
       (fn [ctx-map]
         (edn->html ctx-map)))
     (catch java.lang.RuntimeException _
-      (fn [ctx-map]
-        (str "<pre>"
-             "Include yogthos/json-html for prettier debugging."
-             (str ctx-map)
-             "</pre>")))))
+      basic-edn->html)))
 
 (defn debug-handler [_ _ _ _]
   (fn [context-map]

--- a/src/selmer/tags.clj
+++ b/src/selmer/tags.clj
@@ -1,7 +1,6 @@
 (ns selmer.tags
   (:require
     clojure.java.io
-    clojure.pprint
     selmer.node
     [selmer.filter-parser :refer [safe-filter compile-filter-body get-accessor]]
     [selmer.filters :refer [filters]]
@@ -385,7 +384,7 @@
       (render content (assoc context-map safe-filter true)))))
 
 (def prettify-edn
-  "Resolves to json-html.core/edn->html if available, falls back to clojure.pprint/pprint otherwise.
+  "Resolves to json-html.core/edn->html if available, falls back to more basic rendering otherwise.
   NOTE: It's important for GraalVM native-image that we resolve vars
   at compile time (top-level) rather than at run-time (in a function
   body)."
@@ -395,10 +394,11 @@
       (fn [ctx-map]
         (edn->html ctx-map)))
     (catch java.lang.RuntimeException _
-      (require 'clojure.pprint)
-      (let [pprint @(resolve 'clojure.pprint/pprint)]
-        (fn [ctx-map]
-          (with-out-str (pprint ctx-map)))))))
+      (fn [ctx-map]
+        (str "<pre>"
+             "Include yogthos/json-html for prettier debugging."
+             (str ctx-map)
+             "</pre>")))))
 
 (defn debug-handler [_ _ _ _]
   (fn [context-map]

--- a/src/selmer/tags.clj
+++ b/src/selmer/tags.clj
@@ -386,8 +386,9 @@
 
 (def prettify-edn
   "Resolves to json-html.core/edn->html if available, falls back to clojure.pprint/pprint otherwise.
-  NOTE: It's important that we resolve vars at compile
-  time (top-level) rather than at run-time (in a function body)."
+  NOTE: It's important for GraalVM native-image that we resolve vars
+  at compile time (top-level) rather than at run-time (in a function
+  body)."
   (try
     (require 'json-html.core)
     (let [edn->html @(resolve 'json-html.core/edn->html)]

--- a/src/selmer/util.clj
+++ b/src/selmer/util.clj
@@ -197,10 +197,13 @@
           (looks-like-absolute-file-path? f) (.toURL (.toURI (io/file f)))
           (.startsWith f "file:/") (java.net.URL. f)
           (.startsWith f "jar:file:/") (java.net.URL. f)
-          *url-stream-handler* (java.net.URL. nil f *url-stream-handler*)
+          *url-stream-handler*
+          (java.net.URL. nil f
+                         ^java.net.URLStreamHandler *url-stream-handler*)
           :else (io/resource f)))
       (cond
-        *url-stream-handler* (java.net.URL. nil template *url-stream-handler*)
+        *url-stream-handler* (java.net.URL. nil ^String template
+                                            ^java.net.URLStreamHandler *url-stream-handler*)
         :else (io/resource template)))))
 
 (defn resource-last-modified [^java.net.URL resource]

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -7,7 +7,8 @@
             [selmer.template-parser :refer :all]
             [selmer.util :refer :all]
             [clojure.java.io :as io]
-            [clojure.string :as string])
+            [clojure.string :as string]
+            [clojure.string :as str])
   (:import java.util.Locale
            java.io.File
            (java.io StringReader ByteArrayInputStream)))
@@ -1250,3 +1251,7 @@
                                                 BOOM
                                               {% endifequal %}
                                             {% endfor %}")))))
+
+(deftest debug-test
+  (is (str/includes? (render "{% debug %}" {:debug-value 1})
+                     "debug-value")))

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -1254,4 +1254,6 @@
 
 (deftest debug-test
   (is (str/includes? (render "{% debug %}" {:debug-value 1})
-                     "debug-value")))
+                     "debug-value"))
+  (testing "basic rendering escapes HTML"
+    (println (basic-edn->html {:a "<pre>"}))))


### PR DESCRIPTION
This commit makes the json-html dependency (and its dependencies) optional.
It also fixes some reflection warnings.