### PR TITLE
Whitespace cosmetics

### DIFF
--- a/src/selmer/filter_parser.clj
+++ b/src/selmer/filter_parser.clj
@@ -1,21 +1,22 @@
 (ns selmer.filter-parser
   "Accessors are separated by dots like {{ foo.bar.0 }}
-which gets translated into (get-in context-map [:foo :bar 0]). So you
-can nest vectors and maps in your context-map.
+  which gets translated into (get-in context-map [:foo :bar 0]). So you
+  can nest vectors and maps in your context-map.
 
-Filters can be applied by separating then from the accessor
-with pipes: {{ foo|lower|capitalize }}. They are applied one after
-the other from left to right. Arguments can be passed to a filter
-separated by colons: {{ foo|pluralize:y:ies }}. If an argument includes
-spaces you can enclose it with doublequotes or colons: {{ foo|join:\", \" }}.
+  Filters can be applied by separating then from the accessor
+  with pipes: {{ foo|lower|capitalize }}. They are applied one after
+  the other from left to right. Arguments can be passed to a filter
+  separated by colons: {{ foo|pluralize:y:ies }}. If an argument includes
+  spaces you can enclose it with doublequotes or colons: {{ foo|join:\", \" }}.
 
-You can escape doublequotes inside doublequotes. And you can put colons
-inside doublequotes which will be ignored for the purpose of separating
-arguments."
+  You can escape doublequotes inside doublequotes. And you can put colons
+  inside doublequotes which will be ignored for the purpose of separating
+  arguments."
   (:require
-    [selmer.filters :refer [get-filter]]
-    [selmer.util :refer [exception *escape-variables* fix-accessor parse-accessor]]
-    [clojure.string :as s]))
+   [selmer.filters :refer [get-filter]]
+   [selmer.util :refer [exception *escape-variables* fix-accessor parse-accessor]]
+   [clojure.string :as s]
+   [clojure.string :as str]))
 
 ;;; More Utils
 (defn escape-html*
@@ -135,7 +136,8 @@ applied filter."
   (->> s
        (s/trim)
        ;; Ignore pipes and allow escaped doublequotes inside doublequotes
-       (re-seq #"(?:[^|\"]|\"[^\"]*\")+")))
+       (re-seq #"\w*(?:[^|\"]|\"[^\"]*\")+")
+       (map str/trim)))
 
 (defn compile-filter-body
   "Turns a string like foo|filter1:x|filter2:y into a fn that expects a

--- a/src/selmer/util.clj
+++ b/src/selmer/util.clj
@@ -1,8 +1,7 @@
 (ns selmer.util
   (:require
-   [clojure.java.io :as io]
-   [clojure.string :as string]
-   [clojure.string :as str])
+    [clojure.java.io :as io]
+    [clojure.string :as string])
   (:import java.io.StringReader
            java.util.regex.Pattern
            java.security.MessageDigest))
@@ -91,7 +90,8 @@
 
 (defn read-tag-info [rdr]
   (let [buf      (StringBuilder.)
-        tag-type (if (= *filter-open* (read-char rdr)) :filter :expr)]
+        tag-type (if (= *filter-open* (read-char rdr)) :filter :expr)
+        filter? (identical? :filter tag-type )]
     (loop [ch1 (read-char rdr)
            ch2 (read-char rdr)]
       (when-not (or (nil? ch1)
@@ -101,7 +101,9 @@
         (recur ch2 (read-char rdr))))
     (let [content (->> (.toString buf)
                        (check-tag-args)
-                       (re-seq #"(?:[^\"]|\"[^\"]*\")+")
+                       (re-seq (if filter?
+                                 #"(?:[^\"]|\"[^\"]*\")+"
+                                 #"(?:[^\s\"]|\"[^\"]*\")+"))
                        (remove empty?)
                        (map (fn [^String s] (.trim s))))
           tag-info (merge {:tag-type tag-type}

--- a/src/selmer/util.clj
+++ b/src/selmer/util.clj
@@ -1,7 +1,8 @@
 (ns selmer.util
   (:require
-    [clojure.java.io :as io]
-    [clojure.string :as string])
+   [clojure.java.io :as io]
+   [clojure.string :as string]
+   [clojure.string :as str])
   (:import java.io.StringReader
            java.util.regex.Pattern
            java.security.MessageDigest))
@@ -100,7 +101,7 @@
         (recur ch2 (read-char rdr))))
     (let [content (->> (.toString buf)
                        (check-tag-args)
-                       (re-seq #"(?:[^\s\"]|\"[^\"]*\")+")
+                       (re-seq #"(?:[^\"]|\"[^\"]*\")+")
                        (remove empty?)
                        (map (fn [^String s] (.trim s))))
           tag-info (merge {:tag-type tag-type}

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -1264,3 +1264,6 @@
       (binding [*resource-fn* (fn [_path]
                                 (.toURL (io/file "test/templates/snippet.html")))]
         (render-file "foobar" {:url "foo" :gridid "bar"})))))
+
+(deftest allow-whitespace-in-filter-test
+  (is (= "bar" (render "{{ foo | default:bar }}" {:dude 1}))))


### PR DESCRIPTION
Is there a reason we can't have some whitespace in filters?

``` clojure
(= "bar" (render "{{ foo | default:bar }}" {:dude 1}))
```

This PR makes this possible. Please merge with care. I'm not sure if I will introduce any ambiguity in the syntax that cannot be fixed later.