### PR TITLE
add `opts` to `known-variables` params, to parity w/ `render`

### DIFF
--- a/src/selmer/parser.clj
+++ b/src/selmer/parser.clj
@@ -404,8 +404,9 @@
                  (rest tags)))
         vars))))
 
-(defn known-variables [input]
-  (->> (parse parse-input (java.io.StringReader. input) {})
+(defn known-variables [input & [opts]]
+  (->> (or opts {})
+       (parse parse-input (java.io.StringReader. input))
        meta
        :all-tags
        parse-variables))


### PR DESCRIPTION
This might be necessary for some static generation tools which need to alternate the opening & closing tags in nested files.