### PR TITLE
Fix Clojure 11 warnings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject selmer "1.11.9"
+(defproject selmer "1.11.10"
   :description "Django style templates for Clojure"
   :url "https://github.com/yogthos/Selmer"
   :license {:name "Eclipse Public License"

--- a/src/selmer/tags.clj
+++ b/src/selmer/tags.clj
@@ -113,18 +113,18 @@
 (defn- num? [v]
   (re-matches #"[0-9]*\.?[0-9]+" v))
 
-(defn- parse-double [v]
+(defn- parse-double-value [v]
   (java.lang.Double/parseDouble v))
 
 (defn parse-numeric-params [p1 op p2]
   (let [comparator (match-comparator op)]
     (cond
       (and (not (num? p1)) (not (num? p2)))
-      [#(comparator (parse-double %1) (parse-double %2)) p1 p2]
+      [#(comparator (parse-double-value %1) (parse-double-value %2)) p1 p2]
       (num? p1)
-      [#(comparator (parse-double p1) (parse-double %)) nil p2]
+      [#(comparator (parse-double-value p1) (parse-double-value %)) nil p2]
       (num? p2)
-      [#(comparator (parse-double %) (parse-double p2)) p1 nil])))
+      [#(comparator (parse-double-value %) (parse-double-value p2)) p1 nil])))
 
 (defn render-if-numeric [render negate? [comparator context-key1 context-key2] context-map if-tags else-tags]
   (render


### PR DESCRIPTION
I backported your Clojure 11 warning fixes to the latest selmer 1.11 version, creating a version 1.11.10. If you could please merge it in a branch and generate a version 1.11.10, it would be awesome, so that I could get the warning fixes without having to get the breaking changes from 1.12. Thank you!

The commit to be merged to is this: `5397fa234e6a799e6b1aba8ec560ca5965680763`. It does not have a branch nor a tag right now.