### PR TITLE
REFACTOR parser/parse-variables

### DIFF
--- a/src/selmer/parser.clj
+++ b/src/selmer/parser.clj
@@ -362,93 +362,77 @@
       (parse-fn input params)
       {:all-tags @*tags*})))
 
-(defn- parse-top-level-variable
-  "
-  takes in vals like: \"person.name|capitalize\"
-  and produces :person
-  "
-  [arg]
-  (some-> arg
-          split-value
-          first
-          parse-accessor
-          first))
-
 (defn- parse-variable-paths
   "
   takes in vals like: \"person.name|capitalize\"
   and produces [:person :name]
   "
   [arg]
-  (some-> arg
-          split-value
-          first
-          parse-accessor))
+  (some-> arg split-value first parse-accessor))
 
 ;; List of variables in a template file
-(defn ^:private parse-variables
-  ([tags] (parse-variables tags parse-top-level-variable))
-  ([tags var-fn]
-   (loop [vars        #{}
-          nested-keys #{}
-          tags        tags]
-     (if-let [{:keys [tag-type tag-name tag-value args] :as tag} (first tags)]
-       (cond
-         (= :filter tag-type) (let [v (var-fn tag-value)]
-                                (recur (cond-> vars
-                                         (not (cond
-                                                (keyword? v) (contains? nested-keys v)
-                                                (vector? v)  (contains? nested-keys (first v)))) (conj v))
-                                       nested-keys
-                                       (rest tags)))
-         (= :for tag-name)    (let [[ids [_ items]] (aggregate-args args)]
-                                (recur (conj vars (var-fn items))
-                                       (conj (set (map keyword ids)) :forloop)
-                                       (rest tags)))
+(defn ^:private parse-variables [tags]
+  (loop [vars        #{}
+         nested-keys #{}
+         tags        tags]
+    (if-let [{:keys [tag-type tag-name tag-value args] :as tag} (first tags)]
+      (cond
+        (= :filter tag-type) (let [v               (parse-variable-paths tag-value)
+                                   should-add-var? (when (vector? v)
+                                                     (not (contains? nested-keys (first v))))
+                                   updated-vars    (cond-> vars
+                                                     should-add-var? (conj v))]
+                               (recur
+                                 updated-vars
+                                 nested-keys
+                                 (rest tags)))
+        (= :for tag-name)    (let [[ids [_ items]] (aggregate-args args)]
+                               (recur
+                                 (conj vars (parse-variable-paths items))
+                                 (conj (set (map keyword ids)) :forloop)
+                                 (rest tags)))
 
-         (= :with tag-name) (let [[id value] (string/split (first args) #"=")]
-                              (recur (conj vars (var-fn value))
-                                     #{(keyword id)}
-                                     (rest tags)))
+        (= :with tag-name)   (let [[id value] (string/split (first args) #"=")]
+                               (recur
+                                 (conj vars (parse-variable-paths value))
+                                 #{(keyword id)}
+                                 (rest tags)))
 
-         (contains? #{:endfor :endwith} tag-name) (recur vars #{} (rest tags))
+        (contains? #{:endfor :endwith} tag-name) (recur vars #{} (rest tags))
 
-         :else
-         (let [special-syms   #{nil :not :all :any :< :> := :<= :>=}
-               should-remove? (fn [var]
-                                (if (vector? var)
-                                  (or
-                                    (->> var first special-syms)
-                                    (->> var first nested-keys))
-                                  (or
-                                    (->> var special-syms)
-                                    (->> var nested-keys))))
-               ]
-           (recur (set/union
-                    vars
-                    (->> args
-                         (filter (complement literal?))
-                         (map var-fn)
-                         (remove should-remove?)
-                         set))
-                  nested-keys
-                  (rest tags))))
-       vars))))
+        :else
+        (let [special-syms   #{nil :not :all :any :< :> := :<= :>=}
+              should-remove? (fn [[var-head :as var]]
+                               (or
+                                 (special-syms var-head)
+                                 (nested-keys  var-head)))
+              ]
+          (recur (set/union
+                   vars
+                   (->> args
+                        (filter (complement literal?))
+                        (map parse-variable-paths)
+                        (remove should-remove?)
+                        set))
+                 nested-keys
+                 (rest tags))))
+      vars)))
 
 (defn known-variable-paths [input & [opts]]
-  (let [parser #(-> % (parse-variables parse-variable-paths))]
-    (->> (or opts {})
-         (parse parse-input (java.io.StringReader. input))
-         meta
-         :all-tags
-         parser)))
+  (->> (or opts {})
+       (parse parse-input (java.io.StringReader. input))
+       meta
+       :all-tags
+       parse-variables))
 
 (defn known-variables [input & [opts]]
   (->> (or opts {})
        (parse parse-input (java.io.StringReader. input))
        meta
        :all-tags
-       parse-variables))
+       parse-variables
+       (map first)
+       (into #{})))
 
 (defmacro ^:no-doc env-map
   "Puts &env into a map."


### PR DESCRIPTION
remove condition logic for handling non-path cases and instead always output paths.

parser/known-variables now strips off the head of returned path seqs and returns that.
this logic was previously in parse-variables.