### PR TITLE
feat: `sum` tag handles numeric literals

### DIFF
--- a/src/selmer/tags.clj
+++ b/src/selmer/tags.clj
@@ -267,8 +267,12 @@
 (defn sum-handler [args _ _ _]
   (fn [context-map]
     (reduce + (map (fn [val]
-                     (let [accessor (parse-accessor val)]
-                       (get-in context-map accessor))) args))))
+                     (if (= \\ (first val))
+                       (if (str/includes? val ".")
+                         (parse-double-value (subs val 1))
+                         (Integer/parseInt (subs val 1)))
+                       (let [accessor (parse-accessor val)]
+                         (get-in context-map accessor)))) args))))
 
 (defn now-handler [args _ _ _]
   (fn [context-map]

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -493,7 +493,13 @@
        (render "{% sum foo bar baz %}" {:foo 3 :bar 2 :baz 1})))
   (is
     (= "6"
-       (render "{% sum foo bar.baz %}" {:foo 3 :bar {:baz 3}}))))
+       (render "{% sum foo bar.baz %}" {:foo 3 :bar {:baz 3}})))
+  (is
+    (= "2.2"
+       (render "{% sum foo \\1.1 %}" {:foo 1.1})))
+  (is
+    (= "3"
+       (render "{% sum \\1 \\2 %}" {}))))
 
 
 (deftest tag-info-test


### PR DESCRIPTION
Fixes #150 

We use a backslash to denote the starting of a numeric literal. Feedback is welcome.