### PR TITLE
Added resolve-arg function in selmer.parser which lets you resolve args passed to the handler of custom tags as per request: https://github.com/yogthos/Selmer/issues/303

### DIFF
--- a/src/selmer/parser.clj
+++ b/src/selmer/parser.clj
@@ -12,7 +12,8 @@
     [clojure.string :as string]
     [selmer.template-parser :refer [preprocess-template]]
     [selmer.filters :refer [filters]]
-    [selmer.filter-parser :refer [compile-filter-body literal? split-value]]
+    [selmer.filter-parser :refer [compile-filter-body literal?
+                                  split-value parse-literal]]
     [selmer.tags :refer :all]
     [selmer.util :refer :all]
     [selmer.validator :refer [validation-error]]
@@ -459,3 +460,21 @@
         (mapv #(resolve-var-from-kw ~*ns* (env-map) %))
         (apply merge)
         (render ~s)))
+
+(defn resolve-arg
+  "Resolves an arg as passed to an add-tag! handler using the provided
+  context-map.
+
+  A custom tag handler will receive a seq of args as its first argument.
+  With this function, you can selectively resolve one or more of those args
+  so that if they contain literals, the literal value is returned, and if they
+  contain templates of any sort, which can itself have variables, filters or
+  tags in it, they will be returned resolved, applied and rendered.
+
+  Example:
+    (resolve-arg {{header-name|upper}} {:header-name \"My Page\"})
+    => \"MY PAGE\""
+  [arg context-map]
+  (if (literal? arg)
+    (parse-literal arg)
+    (render arg context-map)))

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -1438,3 +1438,32 @@
 
   (is (= "false" (let [y false] (<< "{{y}}")))
       "<< picks up local values even if they are false"))
+
+(deftest resolve-arg-test
+  (is (= "John"
+         (resolve-arg "{{variable}}" {:variable "John"}))
+      "When arg is a variable, returns it substituted by its value.")
+  (is (= "Hello John!"
+         (resolve-arg "Hello {{variable}}!" {:variable "John"}))
+      "When arg contains a variable, return it with the variable substituted by its value.")
+  (is (= "JOHN"
+         (resolve-arg "{{variable|upper}}" {:variable "John"}))
+      "When arg is a filter, returns it where the filter was applied to its value.")
+  (is (= "Hello JOHN!"
+         (resolve-arg "Hello {{variable|upper}}!" {:variable "John"}))
+      "When arg contains a filter, returns it where the filter was applied to its value.")
+  (is (= "Mr John"
+         (resolve-arg "{% if variable = \"John\" %}Mr {{variable}}{% endif %}" {:variable "John"}))
+      "When arg is a tag, returns it where the tag was rendered to its value.")
+  (is (= "Hello Mr John!"
+         (resolve-arg "Hello {% if variable = \"John\" %}Mr {{variable}}{% endif %}!" {:variable "John"}))
+      "When arg contains a tag, returns it where the tag was rendered to its value.")
+  (is (= "Hello John!"
+         (resolve-arg "\"Hello John!\"" {}))
+      "When arg is a double quoted literal string, returns it without double quoting.")
+  (is (= "Hello John!"
+         (resolve-arg "Hello John!" {}))
+      "When arg is a literal string, returns it as is.")
+  (is (= "29.99"
+         (resolve-arg "29.99" {}))
+      "When arg is a literal number, returns it as is."))


### PR DESCRIPTION
I added resolve-arg to the selmer.parser namespace, let me know if you think it be better to put it in another one.

I've also followed stuart sierra's advice of not having a function that maps and having one for a single element where it's trivial
for users to map over it.

I added to the README how to use it.

I have 3 failing tests on my machine, but they are all for date filter, when using Locale zh, I get some chinese characters as part
of the output, and the time is 12:00 instead of 00:00. Anyways, I did not bother debugging them, since they are clearly unrelated to
my changes.

I did not update the changelog, I think you might want to do that when cutting a new release?

Regards
