### PR TITLE
add support for specifying type attribute of script tag

### DIFF
--- a/src/selmer/tags.clj
+++ b/src/selmer/tags.clj
@@ -354,7 +354,8 @@
   * `async` - when evaluates to logical true then 'async' attribute would be
     added to generated tag.
   * `defer` - when evaluates to logical true then 'defer' attribute would be
-    added to generated tag."
+    added to generated tag.
+  * `type` - when present its value is used for the 'type' attribute."
   [[^String uri & args] _ _ _]
   (let [args
         (->> args
@@ -370,8 +371,9 @@
                            args)
             async-attr   (when (:async args) "async ")
             defer-attr   (when (:defer args) "defer ")
+            type-attr    (or (:type args) "application/javascript")
             src-attr-val (build-uri-for-script-or-style-tag uri context-map)]
-        (str "<script " async-attr defer-attr "src=\"" src-attr-val "\" type=\"application/javascript\"></script>")))))
+        (str "<script " async-attr defer-attr "src=\"" src-attr-val "\" type=\"" type-attr "\"></script>")))))
 
 (defn style-handler
   "Returns function that renders HTML `<LINK/>` tag. Accepts `uri` that would

--- a/test/selmer/core_test.clj
+++ b/test/selmer/core_test.clj
@@ -443,6 +443,14 @@
     (= "<script src=\"/js/site.js\" type=\"application/javascript\"></script>"
       (render "{% script \"/js/site.js\" defer=nil %}" {}))))
 
+(deftest script-type
+  (is
+    (= "<script src=\"/js/site.js\" type=\"module\"></script>"
+       (render "{% script \"/js/site.js\" type=\"module\" %}" {})))
+  (is
+    (= "<script src=\"/js/site.js\" type=\"application/javascript\"></script>"
+       (render "{% script \"/js/site.js\" %}" {}))))
+
 (deftest cycle-test
   (is
     (= "\"foo\"1\"bar\"2\"baz\"1\"foo\"2\"bar\"1"


### PR DESCRIPTION
ESM modules are becoming more common, and as such there is a need to specify `<script type="module" ...>` (or whatever other type one fancies).
